### PR TITLE
Improve price aware pick selection

### DIFF
--- a/MLB/src/common/contracts.py
+++ b/MLB/src/common/contracts.py
@@ -46,6 +46,9 @@ FINAL_PICKS_REQUIRED_COLUMNS = [
     "price",
     "edge",
     "pick_type",
+    "implied_probability",
+    "value_score",
+    "confidence_tier",
 ]
 
 

--- a/MLB/src/odds/create_picks.py
+++ b/MLB/src/odds/create_picks.py
@@ -32,6 +32,15 @@ def _classify_pick_type(edge: float) -> str:
         return "lean"
     return "pass"
 
+def _classify_confidence_tier(value_score: float) -> str:
+    if value_score >= 0.50:
+        return "high"
+    if value_score >= 0.30:
+        return "medium"
+    if value_score >= 0.15:
+        return "low"
+    return "thin"
+
 
 def _american_odds_sort_key(price: float | int | None) -> float:
     """
@@ -180,6 +189,7 @@ def build_daily_picks(joined_df: pd.DataFrame) -> pd.DataFrame:
 
     df["side_norm"] = df["side"].apply(_normalize_side)
     df["price_sort_key"] = df["price"].apply(_american_odds_sort_key)
+    df["implied_probability"] = df["price"].apply(american_to_implied_probability)
 
     best_rows: list[pd.Series] = []
 
@@ -193,6 +203,8 @@ def build_daily_picks(joined_df: pd.DataFrame) -> pd.DataFrame:
 
     picks = pd.DataFrame(best_rows).reset_index(drop=True)
     picks["pick_type"] = picks["edge"].apply(_classify_pick_type)
+    picks["value_score"] = picks["edge"].abs() * (1 - picks["implied_probability"])
+    picks["confidence_tier"] = picks["value_score"].apply(_classify_confidence_tier)
 
     if "player_name" in picks.columns:
         picks["player_name"] = picks["player_name_proj"].combine_first(picks["player_name"])
@@ -215,6 +227,9 @@ def build_daily_picks(joined_df: pd.DataFrame) -> pd.DataFrame:
         "line",
         "price",
         "edge",
+        "implied_probability",
+        "value_score",
+        "confidence_tier",
         "pick_type",
     ]
 
@@ -228,7 +243,7 @@ def build_daily_picks(joined_df: pd.DataFrame) -> pd.DataFrame:
 
     picks = (
         picks.sort_values(
-            by=["pick_type_order", "edge"],
+            by=["pick_type_order", "value_score"],
             ascending=[True, False],
         )
         .drop(columns=["pick_type_order"])

--- a/MLB/src/odds/create_picks.py
+++ b/MLB/src/odds/create_picks.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import pandas as pd
+from odds.value import american_to_implied_probability
 
 from common.contracts import (
     require_columns,

--- a/MLB/src/odds/value.py
+++ b/MLB/src/odds/value.py
@@ -1,0 +1,20 @@
+# MLB/src/odds/value.py
+
+from __future__ import annotations
+
+
+def american_to_implied_probability(price: int | float) -> float:
+    """
+    Convert American odds to implied probability.
+
+    Examples:
+    -120 -> 0.5455
+    +100 -> 0.5000
+    +150 -> 0.4000
+    """
+    price = float(price)
+
+    if price < 0:
+        return abs(price) / (abs(price) + 100)
+
+    return 100 / (price + 100)

--- a/MLB/tests/jobs/test_run_daily_card.py
+++ b/MLB/tests/jobs/test_run_daily_card.py
@@ -64,21 +64,23 @@ def test_run_daily_card_writes_outputs_with_mocked_dependencies(monkeypatch, tmp
     )
 
     picks_df = pd.DataFrame(
-        [
-            {
-                "player_name": "Jacob deGrom",
-                "team": "TEX",
-                "opponent": "SEA",
-                "predicted_strikeouts": 6.8,
-                "book": "DraftKings",
-                "pick_side": "over",
-                "line": 5.5,
-                "price": -120,
-                "edge": 1.3,
-                "pick_type": "official",
-            }
-        ]
-    )
+    [
+        {
+            "player_name": "Jacob deGrom",
+            "team": "TEX",
+            "opponent": "SEA",
+            "predicted_strikeouts": 6.8,
+            "book": "DraftKings",
+            "pick_side": "over",
+            "line": 5.5,
+            "price": -120,
+            "edge": 1.3,
+            "implied_probability": 120 / 220,
+            "value_score": 1.3 * (1 - (120 / 220)),
+            "confidence_tier": "medium",
+            "pick_type": "official",
+        }
+    ])
 
     post_df = picks_df.copy()
 

--- a/MLB/tests/odds/test_create_picks.py
+++ b/MLB/tests/odds/test_create_picks.py
@@ -181,6 +181,9 @@ def test_filter_postable_picks_limits_officials_and_leans():
                 "price": -110,
                 "pick_type": "official",
                 "edge": 1.2,
+                "implied_probability": 110 / 210,
+                "value_score": 1.2 * (1 - (110 / 210)),
+                "confidence_tier": "medium",
             },
             {
                 "player_name": "B",
@@ -190,6 +193,9 @@ def test_filter_postable_picks_limits_officials_and_leans():
                 "price": -105,
                 "pick_type": "official",
                 "edge": 1.1,
+                "implied_probability": 105 / 205,
+                "value_score": 1.1 * (1 - (105 / 205)),
+                "confidence_tier": "medium",
             },
             {
                 "player_name": "C",
@@ -199,6 +205,9 @@ def test_filter_postable_picks_limits_officials_and_leans():
                 "price": 100,
                 "pick_type": "official",
                 "edge": 1.0,
+                "implied_probability": 0.5,
+                "value_score": 0.5,
+                "confidence_tier": "medium",
             },
             {
                 "player_name": "D",
@@ -208,6 +217,9 @@ def test_filter_postable_picks_limits_officials_and_leans():
                 "price": -115,
                 "pick_type": "lean",
                 "edge": 0.6,
+                "implied_probability": 115 / 215,
+                "value_score": 0.6 * (1 - (115 / 215)),
+                "confidence_tier": "low",
             },
             {
                 "player_name": "E",
@@ -217,6 +229,9 @@ def test_filter_postable_picks_limits_officials_and_leans():
                 "price": -110,
                 "pick_type": "lean",
                 "edge": 0.5,
+                "implied_probability": 110 / 210,
+                "value_score": 0.5 * (1 - (110 / 210)),
+                "confidence_tier": "low",
             },
             {
                 "player_name": "F",
@@ -226,6 +241,9 @@ def test_filter_postable_picks_limits_officials_and_leans():
                 "price": -110,
                 "pick_type": "pass",
                 "edge": 0.1,
+                "implied_probability": 110 / 210,
+                "value_score": 0.1 * (1 - (110 / 210)),
+                "confidence_tier": "thin",
             },
         ]
     )
@@ -297,4 +315,92 @@ def test_filter_postable_picks_raises_when_pick_type_missing():
     with pytest.raises(ValueError, match="picks_df is missing required columns"):
         filter_postable_picks(picks_df)
 
+def test_build_daily_picks_adds_implied_probability_value_score_and_confidence_tier():
+    joined_df = pd.DataFrame(
+        [
+            {
+                "player_name_proj": "Jacob deGrom",
+                "team": "TEX",
+                "opponent": "SEA",
+                "predicted_strikeouts": 6.8,
+                "bookmaker": "DraftKings",
+                "side": "Over",
+                "line": 5.5,
+                "price": -120,
+            }
+        ]
+    )
 
+    picks = build_daily_picks(joined_df)
+
+    assert "implied_probability" in picks.columns
+    assert "value_score" in picks.columns
+    assert "confidence_tier" in picks.columns
+
+    expected_edge = 6.8 - 5.5
+    expected_implied_probability = 120 / 220
+    expected_value_score = abs(expected_edge) * (1 - expected_implied_probability)
+
+    assert picks.loc[0, "edge"] == pytest.approx(expected_edge)
+    assert picks.loc[0, "implied_probability"] == pytest.approx(expected_implied_probability)
+    assert picks.loc[0, "value_score"] == pytest.approx(expected_value_score)
+    assert picks.loc[0, "confidence_tier"] in {"high", "medium", "low", "thin"}
+
+def test_build_daily_picks_ranks_same_pick_type_by_value_score_not_raw_edge():
+    joined_df = pd.DataFrame(
+        [
+            {
+                "player_name_proj": "Expensive Bigger Edge",
+                "team": "AAA",
+                "opponent": "BBB",
+                "predicted_strikeouts": 6.3,
+                "bookmaker": "DraftKings",
+                "side": "Over",
+                "line": 5.5,
+                "price": -300,
+            },
+            {
+                "player_name_proj": "Plus Money Smaller Edge",
+                "team": "CCC",
+                "opponent": "DDD",
+                "predicted_strikeouts": 6.26,
+                "bookmaker": "FanDuel",
+                "side": "Over",
+                "line": 5.5,
+                "price": 150,
+            },
+        ]
+    )
+
+    picks = build_daily_picks(joined_df)
+
+    assert len(picks) == 2
+    assert list(picks["pick_type"]) == ["official", "official"]
+    assert picks.loc[0, "player_name"] == "Plus Money Smaller Edge"
+    assert picks.loc[0, "value_score"] > picks.loc[1, "value_score"]
+    assert picks.loc[0, "edge"] < picks.loc[1, "edge"]
+
+def test_filter_postable_picks_preserves_value_fields():
+    picks_df = pd.DataFrame(
+        [
+            {
+                "player_name": "A",
+                "book": "DraftKings",
+                "pick_side": "over",
+                "line": 5.5,
+                "price": -110,
+                "edge": 1.0,
+                "implied_probability": 110 / 210,
+                "value_score": 1.0 * (1 - (110 / 210)),
+                "confidence_tier": "medium",
+                "pick_type": "official",
+            }
+        ]
+    )
+
+    postable = filter_postable_picks(picks_df, max_official=1, max_leans=0)
+
+    assert len(postable) == 1
+    assert "implied_probability" in postable.columns
+    assert "value_score" in postable.columns
+    assert "confidence_tier" in postable.columns

--- a/MLB/tests/odds/test_value.py
+++ b/MLB/tests/odds/test_value.py
@@ -1,0 +1,21 @@
+import pytest
+
+from odds.value import american_to_implied_probability
+
+
+def test_american_to_implied_probability_negative_price():
+    result = american_to_implied_probability(-120)
+
+    assert result == pytest.approx(120 / 220)
+
+
+def test_american_to_implied_probability_even_money():
+    result = american_to_implied_probability(100)
+
+    assert result == pytest.approx(0.5)
+
+
+def test_american_to_implied_probability_positive_price():
+    result = american_to_implied_probability(150)
+
+    assert result == pytest.approx(100 / 250)


### PR DESCRIPTION
## Summary

This PR improves the MLB daily pick-selection layer by adding price-aware value scoring and basic confidence/risk metadata.

Previously, final picks were ranked primarily by raw projection edge against the sportsbook line. This change keeps raw edge visible, but adds implied probability and value scoring so picks can be ranked with sportsbook price taken into account.

## Changes

- Add `odds/value.py` with American odds to implied probability conversion
- Add `implied_probability`, `value_score`, and `confidence_tier` to daily picks
- Update pick ranking to sort by pick type and value score instead of raw edge alone
- Preserve existing official / lean / pass classification based on raw edge
- Update final pick contracts to require the new value fields
- Add tests for odds conversion and price-aware pick ranking
- Preserve existing daily card output behavior

## Why

A pick with the same projection edge can have very different value depending on the sportsbook price. This adds the first layer of market-aware selection without introducing heavier bankroll, CLV, or variance modeling yet.

## Testing

- `python -m pytest tests/`

## Notes

This intentionally does not include:
- bankroll sizing
- closing line value tracking
- historical edge-bucket hit rates
- confidence intervals
- book-specific performance tracking

Those should remain future issues.