### PR TITLE
add file metadata for artifacts and model

### DIFF
--- a/MLB/src/jobs/build_training_artifacts.py
+++ b/MLB/src/jobs/build_training_artifacts.py
@@ -2,13 +2,21 @@
 
 from __future__ import annotations
 
+import json
 import shutil
 from pathlib import Path
 
 import pandas as pd
 
 from common.contracts import validate_pitcher_games_contract, require_columns
-from pitcher_k.config import BASE_FEATURES, RAW_STATCAST_START, RAW_STATCAST_END
+from pitcher_k.config import (
+    BASE_FEATURES,
+    RAW_STATCAST_START,
+    RAW_STATCAST_END,
+    TARGET_COL,
+    TRAIN_SPLIT_DATE,
+    XGB_PARAMS,
+)
 from pitcher_k.data_loader import load_statcast_data
 from pitcher_k.preprocessing import add_outcome_flags
 from pitcher_k.feature_engineering import (
@@ -33,6 +41,7 @@ PREVIOUS_DIR = ARTIFACTS_DIR / "previous"
 MODEL_FILENAME = "model.ubj"
 PITCHER_GAMES_FILENAME = "pitcher_games.csv"
 MODEL_DF_FILENAME = "model_df.csv"
+METADATA_FILENAME = "metadata.json"
 
 
 def ensure_artifact_dirs() -> None:
@@ -46,6 +55,7 @@ def artifact_paths(base_dir: Path) -> dict[str, Path]:
         "model": base_dir / MODEL_FILENAME,
         "pitcher_games": base_dir / PITCHER_GAMES_FILENAME,
         "model_df": base_dir / MODEL_DF_FILENAME,
+        "metadata": base_dir / METADATA_FILENAME,
     }
 
 
@@ -99,7 +109,63 @@ def train_pitcher_k_model(pitcher_games: pd.DataFrame):
     model_df = build_model_df(pitcher_games)
     train_df, test_df = time_split(model_df)
     train_output = train_model(train_df, test_df)
-    return train_output["model"], model_df
+    metadata = build_training_metadata(
+        model_df=model_df,
+        train_df=train_df,
+        test_df=test_df,
+        train_output=train_output,
+    )
+    return train_output["model"], model_df, metadata
+
+
+def _date_range(df: pd.DataFrame) -> dict[str, str | None]:
+    if df.empty:
+        return {"start": None, "end": None}
+
+    game_dates = pd.to_datetime(df["game_date"])
+    return {
+        "start": game_dates.min().strftime("%Y-%m-%d"),
+        "end": game_dates.max().strftime("%Y-%m-%d"),
+    }
+
+
+def _evaluation_metrics(train_output: dict) -> dict[str, float]:
+    y_test = train_output["y_test"]
+    y_pred = train_output["model"].predict(train_output["dtest"])
+    abs_errors = (y_pred - y_test).abs()
+
+    return {
+        "mae": float(abs_errors.mean()),
+        "pred_min": float(y_pred.min()),
+        "pred_max": float(y_pred.max()),
+    }
+
+
+def build_training_metadata(
+    model_df: pd.DataFrame,
+    train_df: pd.DataFrame,
+    test_df: pd.DataFrame,
+    train_output: dict,
+) -> dict:
+    return {
+        "target": TARGET_COL,
+        "features": BASE_FEATURES,
+        "model_params": {
+            "xgb_params": XGB_PARAMS,
+            "num_boost_round": 200,
+        },
+        "training_window": {
+            "raw_statcast_start": RAW_STATCAST_START,
+            "raw_statcast_end": RAW_STATCAST_END,
+            "train_split_date": TRAIN_SPLIT_DATE,
+            "model_df_rows": int(len(model_df)),
+            "train_rows": int(len(train_df)),
+            "test_rows": int(len(test_df)),
+            "train_game_date_range": _date_range(train_df),
+            "test_game_date_range": _date_range(test_df),
+        },
+        "evaluation_metrics": _evaluation_metrics(train_output),
+    }
 
 
 def save_artifacts_to_dir(
@@ -107,6 +173,7 @@ def save_artifacts_to_dir(
     pitcher_games: pd.DataFrame,
     model_df: pd.DataFrame,
     model,
+    metadata: dict,
 ) -> dict[str, Path]:
     output_dir.mkdir(parents=True, exist_ok=True)
     paths = artifact_paths(output_dir)
@@ -114,6 +181,7 @@ def save_artifacts_to_dir(
     pitcher_games.to_csv(paths["pitcher_games"], index=False)
     model_df.to_csv(paths["model_df"], index=False)
     model.save_model(str(paths["model"]))
+    paths["metadata"].write_text(json.dumps(metadata, indent=2), encoding="utf-8")
 
     return paths
 
@@ -138,13 +206,14 @@ def build_training_artifacts() -> tuple[pd.DataFrame, pd.DataFrame, Path, Path]:
     reset_dir(STAGING_DIR)
 
     pitcher_games = build_historical_pitcher_games()
-    model, model_df = train_pitcher_k_model(pitcher_games)
+    model, model_df, metadata = train_pitcher_k_model(pitcher_games)
 
     staging_paths = save_artifacts_to_dir(
         output_dir=STAGING_DIR,
         pitcher_games=pitcher_games,
         model_df=model_df,
         model=model,
+        metadata=metadata,
     )
     validate_saved_artifacts(staging_paths)
 

--- a/MLB/src/jobs/run_daily_card.py
+++ b/MLB/src/jobs/run_daily_card.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 import pandas as pd
@@ -32,6 +33,7 @@ PREVIOUS_ARTIFACTS_DIR = ARTIFACTS_DIR / "previous"
 
 MODEL_PATH = LATEST_ARTIFACTS_DIR / "model.ubj"
 PITCHER_GAMES_PATH = LATEST_ARTIFACTS_DIR / "pitcher_games.csv"
+METADATA_FILENAME = "metadata.json"
 
 OUTPUT_DIR = DATA_DIR / "outputs"
 
@@ -46,41 +48,52 @@ def ensure_output_dirs() -> None:
     PICKS_DIR.mkdir(parents=True, exist_ok=True)
 
 
-def load_pitcher_games_artifact() -> pd.DataFrame:
+def resolve_artifact_path(filename: str) -> Path:
     candidate_paths = [
-        LATEST_ARTIFACTS_DIR / "pitcher_games.csv",
-        PREVIOUS_ARTIFACTS_DIR / "pitcher_games.csv",
+        LATEST_ARTIFACTS_DIR / filename,
+        PREVIOUS_ARTIFACTS_DIR / filename,
     ]
 
     for path in candidate_paths:
         if path.exists():
-            pitcher_games = pd.read_csv(path)
-            pitcher_games["game_date"] = pd.to_datetime(pitcher_games["game_date"])
-            validate_pitcher_games_contract(pitcher_games)
-            print(f"Loaded pitcher_games artifact from: {path}")
-            return pitcher_games
+            return path
 
     raise FileNotFoundError(
-        "Missing pitcher_games artifact in both latest/ and previous/."
+        f"Missing {filename} artifact in both latest/ and previous/."
     )
+
+
+def load_pitcher_games_artifact() -> pd.DataFrame:
+    path = resolve_artifact_path("pitcher_games.csv")
+    pitcher_games = pd.read_csv(path)
+    pitcher_games["game_date"] = pd.to_datetime(pitcher_games["game_date"])
+    validate_pitcher_games_contract(pitcher_games)
+    print(f"Loaded pitcher_games artifact from: {path}")
+    return pitcher_games
 
 
 def load_model_artifact():
-    candidate_paths = [
-        LATEST_ARTIFACTS_DIR / "model.ubj",
-        PREVIOUS_ARTIFACTS_DIR / "model.ubj",
-    ]
+    path = resolve_artifact_path("model.ubj")
+    model = xgb.Booster()
+    model.load_model(str(path))
+    print(f"Loaded model artifact from: {path}")
+    return model
 
-    for path in candidate_paths:
-        if path.exists():
-            model = xgb.Booster()
-            model.load_model(str(path))
-            print(f"Loaded model artifact from: {path}")
-            return model
 
-    raise FileNotFoundError(
-        "Missing model artifact in both latest/ and previous/."
-    )
+def load_model_metadata() -> dict:
+    model_path = resolve_artifact_path("model.ubj")
+    metadata_path = model_path.with_name(METADATA_FILENAME)
+
+    if not metadata_path.exists():
+        raise FileNotFoundError(
+            f"Missing metadata artifact paired with model: {metadata_path}"
+        )
+
+    metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
+    print(f"Loaded model metadata from: {metadata_path}")
+    print("Model metadata:")
+    print(json.dumps(metadata, indent=2))
+    return metadata
 
 
 def build_today_predictions(starters_df: pd.DataFrame, pitcher_games: pd.DataFrame, model):
@@ -131,6 +144,7 @@ def run_daily_card() -> tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame, pd.DataF
     validate_starters_contract(starters_df)
     pitcher_games = load_pitcher_games_artifact()
     model = load_model_artifact()
+    load_model_metadata()
 
     today_preds = build_today_predictions(
         starters_df=starters_df,

--- a/MLB/tests/jobs/test_build_training_artifacts.py
+++ b/MLB/tests/jobs/test_build_training_artifacts.py
@@ -1,0 +1,65 @@
+import json
+
+import pandas as pd
+
+from jobs import build_training_artifacts as training_job
+
+
+class FakeModel:
+    def save_model(self, path: str) -> None:
+        with open(path, "w", encoding="utf-8") as handle:
+            handle.write("fake-model")
+
+
+def test_save_artifacts_to_dir_writes_metadata_json(tmp_path):
+    output_dir = tmp_path / "artifacts"
+    pitcher_games = pd.DataFrame([{"game_date": "2026-04-19", "pitcher": 1}])
+    model_df = pd.DataFrame([{"game_date": "2026-04-19", "strikeouts": 7}])
+    metadata = {
+        "target": "strikeouts",
+        "features": ["pitches_last3"],
+        "model_params": {"xgb_params": {"max_depth": 4}},
+        "training_window": {"train_split_date": "2025-08-01"},
+        "evaluation_metrics": {"mae": 0.91},
+    }
+
+    paths = training_job.save_artifacts_to_dir(
+        output_dir=output_dir,
+        pitcher_games=pitcher_games,
+        model_df=model_df,
+        model=FakeModel(),
+        metadata=metadata,
+    )
+
+    saved_metadata = json.loads(paths["metadata"].read_text(encoding="utf-8"))
+
+    assert paths["metadata"].exists()
+    assert saved_metadata == metadata
+
+
+def test_promote_latest_to_previous_preserves_matching_metadata(tmp_path, monkeypatch):
+    latest_dir = tmp_path / "artifacts" / "latest"
+    previous_dir = tmp_path / "artifacts" / "previous"
+    latest_dir.mkdir(parents=True, exist_ok=True)
+    previous_dir.mkdir(parents=True, exist_ok=True)
+
+    latest_paths = training_job.artifact_paths(latest_dir)
+    latest_paths["model"].write_text("model-bytes", encoding="utf-8")
+    latest_paths["pitcher_games"].write_text("game_date\n2026-04-19\n", encoding="utf-8")
+    latest_paths["model_df"].write_text("game_date,strikeouts\n2026-04-19,7\n", encoding="utf-8")
+    latest_paths["metadata"].write_text(
+        '{"target": "strikeouts", "training_window": {"train_split_date": "2025-08-01"}}',
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(training_job, "LATEST_DIR", latest_dir)
+    monkeypatch.setattr(training_job, "PREVIOUS_DIR", previous_dir)
+
+    training_job.promote_latest_to_previous()
+
+    previous_paths = training_job.artifact_paths(previous_dir)
+    saved_metadata = json.loads(previous_paths["metadata"].read_text(encoding="utf-8"))
+
+    assert previous_paths["model"].read_text(encoding="utf-8") == "model-bytes"
+    assert saved_metadata["target"] == "strikeouts"
+    assert saved_metadata["training_window"]["train_split_date"] == "2025-08-01"

--- a/MLB/tests/jobs/test_run_daily_card.py
+++ b/MLB/tests/jobs/test_run_daily_card.py
@@ -89,6 +89,11 @@ def test_run_daily_card_writes_outputs_with_mocked_dependencies(monkeypatch, tmp
     monkeypatch.setattr(daily_card, "load_model_artifact", lambda: "fake_model")
     monkeypatch.setattr(
         daily_card,
+        "load_model_metadata",
+        lambda: {"target": "strikeouts", "features": ["pitches_last3"]},
+    )
+    monkeypatch.setattr(
+        daily_card,
         "build_today_predictions",
         lambda starters_df, pitcher_games, model: today_preds,
     )
@@ -175,6 +180,11 @@ def test_run_daily_card_raises_when_today_predictions_are_empty(monkeypatch, tmp
     monkeypatch.setattr(daily_card, "load_model_artifact", lambda: "fake_model")
     monkeypatch.setattr(
         daily_card,
+        "load_model_metadata",
+        lambda: {"target": "strikeouts", "features": ["pitches_last3"]},
+    )
+    monkeypatch.setattr(
+        daily_card,
         "build_today_predictions",
         lambda starters_df, pitcher_games, model: pd.DataFrame(),
     )
@@ -221,3 +231,33 @@ def test_run_daily_card_raises_when_pitcher_games_artifact_is_missing(monkeypatc
 
     with pytest.raises(FileNotFoundError, match="Missing pitcher_games artifact"):
         daily_card.run_daily_card()
+
+
+def test_load_model_metadata_reads_matching_file_from_selected_artifact_dir(tmp_path, monkeypatch, capsys):
+    latest_dir = tmp_path / "artifacts" / "latest"
+    previous_dir = tmp_path / "artifacts" / "previous"
+    latest_dir.mkdir(parents=True, exist_ok=True)
+    previous_dir.mkdir(parents=True, exist_ok=True)
+
+    latest_model = latest_dir / "model.ubj"
+    latest_model.write_text("placeholder", encoding="utf-8")
+    (latest_dir / "metadata.json").write_text(
+        '{"target": "strikeouts", "features": ["pitches_last3"], "evaluation_metrics": {"mae": 0.9}}',
+        encoding="utf-8",
+    )
+    (previous_dir / "model.ubj").write_text("older-placeholder", encoding="utf-8")
+    (previous_dir / "metadata.json").write_text(
+        '{"target": "old_target"}',
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(daily_card, "LATEST_ARTIFACTS_DIR", latest_dir)
+    monkeypatch.setattr(daily_card, "PREVIOUS_ARTIFACTS_DIR", previous_dir)
+
+    metadata = daily_card.load_model_metadata()
+    captured = capsys.readouterr()
+
+    assert metadata["target"] == "strikeouts"
+    assert metadata["evaluation_metrics"]["mae"] == 0.9
+    assert str(latest_dir / "metadata.json") in captured.out
+    assert '"target": "strikeouts"' in captured.out


### PR DESCRIPTION
This PR adds a simple metadata.json alongside each trained model artifact so promoted models can be traced back to how they were trained.

It updates the training artifact job to save metadata with each model, including the target, feature set, model params, training window, and evaluation metrics. Because promotion continues to copy the full artifact directory, the matching metadata now moves with latest/previous automatically.

It also updates the daily card job to load and print the metadata for the active model artifact, making it easier to see exactly which trained configuration a run is using.