### PR TITLE
validate df to clear source of truth

### DIFF
--- a/MLB/src/common/contracts.py
+++ b/MLB/src/common/contracts.py
@@ -52,6 +52,31 @@ FINAL_PICKS_REQUIRED_COLUMNS = [
 ]
 
 
+def validate_dataframe_contract(
+    df: pd.DataFrame,
+    *,
+    name: str,
+    required_columns: Sequence[str],
+    non_null_columns: Sequence[str] = (),
+    unique_keys: Sequence[str] = (),
+    boolean_like_int_columns: Sequence[str] = (),
+    require_non_empty_frame: bool = True,
+) -> None:
+    require_columns(df, required_columns, name)
+
+    if require_non_empty_frame:
+        assert_non_empty(df, name)
+
+    if non_null_columns:
+        assert_non_null_columns(df, non_null_columns, name)
+
+    if unique_keys:
+        assert_no_duplicate_keys(df, unique_keys, name)
+
+    for column in boolean_like_int_columns:
+        assert_boolean_like_int_column(df, column, name)
+
+
 def require_columns(df: pd.DataFrame, columns: Sequence[str], name: str) -> None:
     missing = [col for col in columns if col not in df.columns]
     if missing:
@@ -114,11 +139,11 @@ def assert_boolean_like_int_column(
 
 
 def validate_starters_contract(df: pd.DataFrame) -> None:
-    require_columns(df, STARTERS_REQUIRED_COLUMNS, "starters_df")
-    assert_non_empty(df, "starters_df")
-    assert_non_null_columns(
+    validate_dataframe_contract(
         df,
-        [
+        name="starters_df",
+        required_columns=STARTERS_REQUIRED_COLUMNS,
+        non_null_columns=[
             "game_date",
             "game_pk",
             "player_name",
@@ -128,46 +153,47 @@ def validate_starters_contract(df: pd.DataFrame) -> None:
             "away_team",
             "is_home",
         ],
-        "starters_df",
+        unique_keys=["game_date", "game_pk", "player_name"],
+        boolean_like_int_columns=["is_home"],
     )
-    assert_no_duplicate_keys(
-        df,
-        ["game_date", "game_pk", "player_name"],
-        "starters_df",
-    )
-    assert_boolean_like_int_column(df, "is_home", "starters_df")
 
 
 def validate_pitcher_games_contract(df: pd.DataFrame) -> None:
-    require_columns(df, PITCHER_GAMES_REQUIRED_COLUMNS, "pitcher_games")
-    assert_non_empty(df, "pitcher_games")
-    assert_non_null_columns(
+    validate_dataframe_contract(
         df,
-        ["game_date", "game_pk", "pitcher", "player_name"],
-        "pitcher_games",
-    )
-    assert_no_duplicate_keys(
-        df,
-        ["game_date", "game_pk", "pitcher"],
-        "pitcher_games",
+        name="pitcher_games",
+        required_columns=PITCHER_GAMES_REQUIRED_COLUMNS,
+        non_null_columns=["game_date", "game_pk", "pitcher", "player_name"],
+        unique_keys=["game_date", "game_pk", "pitcher"],
     )
 
 
 def validate_joined_odds_contract(df: pd.DataFrame) -> None:
-    require_columns(df, JOINED_ODDS_REQUIRED_COLUMNS, "joined_odds_df")
-    assert_non_empty(df, "joined_odds_df")
-    assert_non_null_columns(
+    validate_dataframe_contract(
         df,
-        ["player_name_proj", "predicted_strikeouts", "bookmaker", "side", "line"],
-        "joined_odds_df",
+        name="joined_odds_df",
+        required_columns=JOINED_ODDS_REQUIRED_COLUMNS,
+        non_null_columns=[
+            "player_name_proj",
+            "predicted_strikeouts",
+            "bookmaker",
+            "side",
+            "line",
+        ],
     )
 
 
 def validate_final_picks_contract(df: pd.DataFrame) -> None:
-    require_columns(df, FINAL_PICKS_REQUIRED_COLUMNS, "final_picks_df")
-    assert_non_empty(df, "final_picks_df")
-    assert_non_null_columns(
+    validate_dataframe_contract(
         df,
-        ["player_name", "book", "pick_side", "line", "edge", "pick_type"],
-        "final_picks_df",
+        name="final_picks_df",
+        required_columns=FINAL_PICKS_REQUIRED_COLUMNS,
+        non_null_columns=[
+            "player_name",
+            "book",
+            "pick_side",
+            "line",
+            "edge",
+            "pick_type",
+        ],
     )

--- a/MLB/src/pitcher_k/slate.py
+++ b/MLB/src/pitcher_k/slate.py
@@ -4,19 +4,13 @@ from __future__ import annotations
 
 import pandas as pd
 
+from common.contracts import (
+    STARTERS_REQUIRED_COLUMNS,
+    require_columns,
+    validate_starters_contract,
+)
 
-SLATE_COLUMNS = [
-    "game_date",
-    "game_pk",
-    "pitcher",
-    "player_name",
-    "team",
-    "opponent",
-    "home_team",
-    "away_team",
-    "is_home",
-    "p_throws",
-]
+SLATE_COLUMNS = STARTERS_REQUIRED_COLUMNS
 
 
 
@@ -31,9 +25,7 @@ def load_tomorrow_slate_from_csv(path: str) -> pd.DataFrame:
     """
     df = pd.read_csv(path)
 
-    missing = [c for c in SLATE_COLUMNS if c not in df.columns]
-    if missing:
-        raise ValueError(f"Missing required columns in slate CSV: {missing}")
+    require_columns(df, SLATE_COLUMNS, "starters_df")
 
     df = df[SLATE_COLUMNS].copy()
     df["game_date"] = pd.to_datetime(df["game_date"])
@@ -52,11 +44,7 @@ def validate_slate(df: pd.DataFrame) -> pd.DataFrame:
     df = df.copy()
 
     df = df.drop_duplicates(subset=["game_date", "game_pk", "pitcher"])
-
-    required_non_null = ["game_date", "game_pk", "pitcher", "player_name", "team", "opponent"]
-    for col in required_non_null:
-        if df[col].isna().any():
-            raise ValueError(f"Column '{col}' contains null values.")
+    validate_starters_contract(df)
 
     return df
 

--- a/MLB/src/starters/config.py
+++ b/MLB/src/starters/config.py
@@ -12,16 +12,3 @@ DATA_DIR = PROJECT_ROOT / "data"
 STARTERS_INPUT_DIR = DATA_DIR / "inputs" / "starters"
 
 TODAY_STARTERS_FILENAME = "today_starters.csv"
-
-REQUIRED_STARTER_COLUMNS = [
-    "game_date",
-    "game_pk",
-    "pitcher",
-    "player_name",
-    "team",
-    "opponent",
-    "home_team",
-    "away_team",
-    "is_home",
-    "p_throws",
-]

--- a/MLB/src/starters/today_starters.py
+++ b/MLB/src/starters/today_starters.py
@@ -121,8 +121,8 @@ def build_today_starters_df(raw_df: pd.DataFrame) -> pd.DataFrame:
     expected by the pitcher_k pipeline.
     """
     starters_df = finalize_starters_df(raw_df)
+    validate_starters_contract(starters_df)
     validate_starters_df(starters_df)
-    validate_starters_contract(starters_df) # shared contract
     return starters_df
 
 

--- a/MLB/src/starters/validate.py
+++ b/MLB/src/starters/validate.py
@@ -4,45 +4,6 @@ from __future__ import annotations
 
 import pandas as pd
 
-from .config import REQUIRED_STARTER_COLUMNS
-
-
-def validate_required_columns(df: pd.DataFrame) -> None:
-    missing = [col for col in REQUIRED_STARTER_COLUMNS if col not in df.columns]
-    if missing:
-        raise ValueError(f"Missing required starter columns: {missing}")
-
-
-def validate_no_nulls(df: pd.DataFrame) -> None:
-    required_non_null = [
-        "game_date",
-        "player_name",
-        "team",
-        "opponent",
-        "home_team",
-        "away_team",
-        "is_home",
-    ]
-
-    null_counts = df[required_non_null].isnull().sum()
-    bad = null_counts[null_counts > 0]
-
-    if not bad.empty:
-        raise ValueError(
-            f"Nulls found in starter slate required fields: {bad.to_dict()}"
-        )
-
-
-def validate_one_row_per_pitcher_game(df: pd.DataFrame) -> None:
-    dupes = df.duplicated(subset=["game_date", "game_pk", "player_name"], keep=False)
-    if dupes.any():
-        bad_rows = df.loc[dupes, ["game_date", "game_pk", "player_name"]]
-        raise ValueError(
-            "Duplicate pitcher rows found in starter slate: "
-            f"{bad_rows.to_dict(orient='records')}"
-        )
-
-
 def validate_home_away_logic(df: pd.DataFrame) -> None:
     bad_home = df[(df["is_home"] == 1) & (df["team"] != df["home_team"])]
     bad_away = df[(df["is_home"] == 0) & (df["team"] != df["away_team"])]
@@ -52,7 +13,4 @@ def validate_home_away_logic(df: pd.DataFrame) -> None:
 
 
 def validate_starters_df(df: pd.DataFrame) -> None:
-    validate_required_columns(df)
-    validate_no_nulls(df)
-    validate_one_row_per_pitcher_game(df)
     validate_home_away_logic(df)

--- a/MLB/tests/starters/test_validate.py
+++ b/MLB/tests/starters/test_validate.py
@@ -1,6 +1,7 @@
 import pandas as pd
 import pytest
 
+from common.contracts import validate_starters_contract
 from starters.validate import validate_starters_df
 
 
@@ -40,18 +41,26 @@ def test_validate_starters_df_passes_on_valid_input():
     validate_starters_df(df)
 
 
-def test_validate_starters_df_raises_on_missing_required_column():
+def test_validate_starters_contract_raises_on_missing_required_column():
     df = _valid_starters_df().drop(columns=["team"])
 
-    with pytest.raises(ValueError, match="Missing required starter columns"):
-        validate_starters_df(df)
+    with pytest.raises(ValueError, match="starters_df is missing required columns"):
+        validate_starters_contract(df)
 
 
-def test_validate_starters_df_raises_on_duplicate_pitcher_rows():
+def test_validate_starters_contract_raises_on_duplicate_pitcher_rows():
     df = pd.concat([_valid_starters_df(), _valid_starters_df().iloc[[0]]], ignore_index=True)
 
-    with pytest.raises(ValueError, match="Duplicate pitcher rows found"):
-        validate_starters_df(df)
+    with pytest.raises(ValueError, match="starters_df has duplicate rows"):
+        validate_starters_contract(df)
+
+
+def test_validate_starters_contract_raises_on_required_nulls():
+    df = _valid_starters_df()
+    df.loc[0, "team"] = None
+
+    with pytest.raises(ValueError, match="starters_df has null values in required columns"):
+        validate_starters_contract(df)
 
 
 def test_validate_starters_df_raises_on_bad_home_away_logic():


### PR DESCRIPTION
This branch continues the move toward shared dataframe contracts by making common/contracts.py the default home for reusable schema validation. Shared checks like required columns, non-null requirements, duplicate-key enforcement, and boolean-like field validation are now centralized instead of being reimplemented in module-local validators.

In starters, the local validator was reduced to the rule that is actually domain-specific: home/away team consistency. Starter contract checks now run through the shared contract path, and pitcher_k/slate.py now reuses the shared starter column contract instead of maintaining its own copy.

Why
Validation logic was split between shared contracts and module-local code, which created a drift risk as the codebase grows. This change makes the source of truth clearer and keeps module-local validation focused on domain meaning rather than generic schema checks.

What changed

Added a shared validate_dataframe_contract(...) helper in MLB/src/common/contracts.py
Routed shared contract validators through that helper
Removed duplicated starter schema/null/duplicate checks from MLB/src/starters/validate.py
Kept only the starter-specific home/away consistency rule locally
Reused shared starter columns/contract checks in MLB/src/pitcher_k/slate.py
Updated tests to distinguish shared contract failures from starter-specific validation failures
Validation

Targeted starter, feature, and daily card job tests passed locally via the project virtualenv