### PR TITLE
picks policy instead of hardcoded leans

### DIFF
--- a/MLB/src/odds/create_picks.py
+++ b/MLB/src/odds/create_picks.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import pandas as pd
 from odds.value import american_to_implied_probability
+from odds.policy import DEFAULT_MLB_PITCHER_STRIKEOUT_POLICY, PickRankingPolicy
 
 from common.contracts import (
     require_columns,
@@ -12,34 +13,10 @@ from common.contracts import (
 )
 
 
-OFFICIAL_EDGE_THRESHOLD = 0.75
-LEAN_EDGE_THRESHOLD = 0.40
-
-
 def _normalize_side(value: str) -> str:
     if not isinstance(value, str):
         return ""
     return value.strip().lower()
-
-
-
-def _classify_pick_type(edge: float) -> str:
-    abs_edge = abs(edge)
-
-    if abs_edge >= OFFICIAL_EDGE_THRESHOLD:
-        return "official"
-    if abs_edge >= LEAN_EDGE_THRESHOLD:
-        return "lean"
-    return "pass"
-
-def _classify_confidence_tier(value_score: float) -> str:
-    if value_score >= 0.50:
-        return "high"
-    if value_score >= 0.30:
-        return "medium"
-    if value_score >= 0.15:
-        return "low"
-    return "thin"
 
 
 def _american_odds_sort_key(price: float | int | None) -> float:
@@ -53,41 +30,10 @@ def _american_odds_sort_key(price: float | int | None) -> float:
     return float(price)
 
 
-def _select_best_over_market(player_df: pd.DataFrame) -> pd.Series:
-    """
-    For overs:
-    - prefer the lowest line
-    - then prefer the best price
-    """
-    over_df = player_df[player_df["side_norm"] == "over"].copy()
-    if over_df.empty:
-        return pd.Series(dtype="object")
-
-    over_df = over_df.sort_values(
-        by=["line", "price_sort_key"],
-        ascending=[True, False],
-    )
-    return over_df.iloc[0]
-
-
-def _select_best_under_market(player_df: pd.DataFrame) -> pd.Series:
-    """
-    For unders:
-    - prefer the highest line
-    - then prefer the best price
-    """
-    under_df = player_df[player_df["side_norm"] == "under"].copy()
-    if under_df.empty:
-        return pd.Series(dtype="object")
-
-    under_df = under_df.sort_values(
-        by=["line", "price_sort_key"],
-        ascending=[False, False],
-    )
-    return under_df.iloc[0]
-
-
-def _choose_best_market_for_player(player_df: pd.DataFrame) -> pd.Series:
+def _choose_best_market_for_player(
+    player_df: pd.DataFrame,
+    policy: PickRankingPolicy,
+) -> pd.Series:
     """
     Choose the best market based on the player's strongest edge direction.
     Expects all rows in player_df to belong to the same player.
@@ -100,46 +46,20 @@ def _choose_best_market_for_player(player_df: pd.DataFrame) -> pd.Series:
 
     predicted = float(player_df["predicted_strikeouts"].iloc[0])
 
-    best_over = _select_best_over_market(player_df)
-    best_under = _select_best_under_market(player_df)
+    best_over = policy.select_best_market(player_df, "over")
+    best_under = policy.select_best_market(player_df, "under")
 
-    over_edge = None
-    under_edge = None
-
-    if not best_over.empty:
-        over_edge = predicted - float(best_over["line"])
-
-    if not best_under.empty:
-        under_edge = float(best_under["line"]) - predicted
-
-    if over_edge is None and under_edge is None:
-        return pd.Series(dtype="object")
-
-    if over_edge is None:
-        chosen = best_under.copy()
-        chosen["edge"] = under_edge
-        chosen["pick_side"] = "under"
-        return chosen
-
-    if under_edge is None:
-        chosen = best_over.copy()
-        chosen["edge"] = over_edge
-        chosen["pick_side"] = "over"
-        return chosen
-
-    if over_edge >= under_edge:
-        chosen = best_over.copy()
-        chosen["edge"] = over_edge
-        chosen["pick_side"] = "over"
-        return chosen
-
-    chosen = best_under.copy()
-    chosen["edge"] = under_edge
-    chosen["pick_side"] = "under"
-    return chosen
+    return policy.choose_pick_side(
+        best_over=best_over,
+        best_under=best_under,
+        predicted=predicted,
+    )
 
 
-def build_daily_picks(joined_df: pd.DataFrame) -> pd.DataFrame:
+def build_daily_picks(
+    joined_df: pd.DataFrame,
+    policy: PickRankingPolicy = DEFAULT_MLB_PITCHER_STRIKEOUT_POLICY,
+) -> pd.DataFrame:
     """
     Build final daily picks from joined projections + odds rows.
 
@@ -194,7 +114,7 @@ def build_daily_picks(joined_df: pd.DataFrame) -> pd.DataFrame:
     best_rows: list[pd.Series] = []
 
     for _, player_df in df.groupby("player_name_proj", sort=False):
-        best_row = _choose_best_market_for_player(player_df)
+        best_row = _choose_best_market_for_player(player_df, policy)
         if not best_row.empty:
             best_rows.append(best_row)
 
@@ -202,9 +122,9 @@ def build_daily_picks(joined_df: pd.DataFrame) -> pd.DataFrame:
         return pd.DataFrame()
 
     picks = pd.DataFrame(best_rows).reset_index(drop=True)
-    picks["pick_type"] = picks["edge"].apply(_classify_pick_type)
+    picks["pick_type"] = picks["edge"].apply(policy.classify_pick_type)
     picks["value_score"] = picks["edge"].abs() * (1 - picks["implied_probability"])
-    picks["confidence_tier"] = picks["value_score"].apply(_classify_confidence_tier)
+    picks["confidence_tier"] = picks["value_score"].apply(policy.classify_confidence_tier)
 
     if "player_name" in picks.columns:
         picks["player_name"] = picks["player_name_proj"].combine_first(picks["player_name"])
@@ -238,17 +158,7 @@ def build_daily_picks(joined_df: pd.DataFrame) -> pd.DataFrame:
 
     picks = picks[existing_cols + other_cols]
 
-    pick_type_order = {"official": 0, "lean": 1, "pass": 2}
-    picks["pick_type_order"] = picks["pick_type"].map(pick_type_order).fillna(99)
-
-    picks = (
-        picks.sort_values(
-            by=["pick_type_order", "value_score"],
-            ascending=[True, False],
-        )
-        .drop(columns=["pick_type_order"])
-        .reset_index(drop=True)
-    )
+    picks = policy.sort_picks(picks)
 
     validate_final_picks_contract(picks)
     return picks
@@ -256,8 +166,9 @@ def build_daily_picks(joined_df: pd.DataFrame) -> pd.DataFrame:
 
 def filter_postable_picks(
     picks_df: pd.DataFrame,
-    max_official: int = 4,
-    max_leans: int = 2,
+    max_official: int | None = None,
+    max_leans: int | None = None,
+    policy: PickRankingPolicy = DEFAULT_MLB_PITCHER_STRIKEOUT_POLICY,
 ) -> pd.DataFrame:
     """
     Return a smaller set of picks to post publicly.
@@ -267,8 +178,13 @@ def filter_postable_picks(
 
     require_columns(picks_df, ["pick_type"], "picks_df")
 
-    officials = picks_df[picks_df["pick_type"] == "official"].head(max_official)
-    leans = picks_df[picks_df["pick_type"] == "lean"].head(max_leans)
+    limits = policy.resolved_postable_limits(
+        max_official=max_official,
+        max_leans=max_leans,
+    )
+
+    officials = picks_df[picks_df["pick_type"] == "official"].head(limits.max_official)
+    leans = picks_df[picks_df["pick_type"] == "lean"].head(limits.max_leans)
 
     result = pd.concat([officials, leans], ignore_index=True)
 

--- a/MLB/src/odds/policy.py
+++ b/MLB/src/odds/policy.py
@@ -1,0 +1,171 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+import pandas as pd
+
+
+@dataclass(frozen=True)
+class MarketRankingRule:
+    side: str
+    sort_by: tuple[str, ...]
+    ascending: tuple[bool, ...]
+
+
+@dataclass(frozen=True)
+class PostablePickLimits:
+    max_official: int = 4
+    max_leans: int = 2
+
+
+@dataclass(frozen=True)
+class PickRankingPolicy:
+    official_edge_threshold: float
+    lean_edge_threshold: float
+    confidence_tier_thresholds: tuple[tuple[str, float], ...]
+    confidence_default_tier: str
+    market_ranking_rules: tuple[MarketRankingRule, ...]
+    edge_tie_preference: str
+    pick_type_order: tuple[str, ...]
+    postable_limits: PostablePickLimits = field(default_factory=PostablePickLimits)
+
+    def classify_pick_type(self, edge: float) -> str:
+        abs_edge = abs(edge)
+
+        if abs_edge >= self.official_edge_threshold:
+            return "official"
+        if abs_edge >= self.lean_edge_threshold:
+            return "lean"
+        return "pass"
+
+    def classify_confidence_tier(self, value_score: float) -> str:
+        for tier_name, threshold in self.confidence_tier_thresholds:
+            if value_score >= threshold:
+                return tier_name
+        return self.confidence_default_tier
+
+    def select_best_market(self, player_df: pd.DataFrame, side: str) -> pd.Series:
+        rule = self._market_rule_for_side(side)
+        side_df = player_df[player_df["side_norm"] == rule.side].copy()
+        if side_df.empty:
+            return pd.Series(dtype="object")
+
+        side_df = side_df.sort_values(
+            by=list(rule.sort_by),
+            ascending=list(rule.ascending),
+        )
+        return side_df.iloc[0]
+
+    def choose_pick_side(
+        self,
+        *,
+        best_over: pd.Series,
+        best_under: pd.Series,
+        predicted: float,
+    ) -> pd.Series:
+        over_edge = None
+        under_edge = None
+
+        if not best_over.empty:
+            over_edge = predicted - float(best_over["line"])
+
+        if not best_under.empty:
+            under_edge = float(best_under["line"]) - predicted
+
+        if over_edge is None and under_edge is None:
+            return pd.Series(dtype="object")
+
+        if over_edge is None:
+            return self._finalize_choice(best_under, edge=under_edge, pick_side="under")
+
+        if under_edge is None:
+            return self._finalize_choice(best_over, edge=over_edge, pick_side="over")
+
+        if over_edge > under_edge:
+            return self._finalize_choice(best_over, edge=over_edge, pick_side="over")
+
+        if under_edge > over_edge:
+            return self._finalize_choice(best_under, edge=under_edge, pick_side="under")
+
+        if self.edge_tie_preference == "under":
+            return self._finalize_choice(best_under, edge=under_edge, pick_side="under")
+
+        return self._finalize_choice(best_over, edge=over_edge, pick_side="over")
+
+    def sort_picks(self, picks_df: pd.DataFrame) -> pd.DataFrame:
+        order_lookup = {
+            pick_type: rank
+            for rank, pick_type in enumerate(self.pick_type_order)
+        }
+        picks = picks_df.copy()
+        picks["pick_type_order"] = picks["pick_type"].map(order_lookup).fillna(99)
+        return (
+            picks.sort_values(
+                by=["pick_type_order", "value_score"],
+                ascending=[True, False],
+            )
+            .drop(columns=["pick_type_order"])
+            .reset_index(drop=True)
+        )
+
+    def resolved_postable_limits(
+        self,
+        *,
+        max_official: int | None = None,
+        max_leans: int | None = None,
+    ) -> PostablePickLimits:
+        return PostablePickLimits(
+            max_official=(
+                self.postable_limits.max_official
+                if max_official is None
+                else max_official
+            ),
+            max_leans=(
+                self.postable_limits.max_leans
+                if max_leans is None
+                else max_leans
+            ),
+        )
+
+    def _market_rule_for_side(self, side: str) -> MarketRankingRule:
+        for rule in self.market_ranking_rules:
+            if rule.side == side:
+                return rule
+        raise ValueError(f"No market ranking rule configured for side '{side}'.")
+
+    @staticmethod
+    def _finalize_choice(row: pd.Series, *, edge: float, pick_side: str) -> pd.Series:
+        chosen = row.copy()
+        chosen["edge"] = edge
+        chosen["pick_side"] = pick_side
+        return chosen
+
+
+DEFAULT_MLB_PITCHER_STRIKEOUT_POLICY = PickRankingPolicy(
+    official_edge_threshold=0.75,
+    lean_edge_threshold=0.40,
+    confidence_tier_thresholds=(
+        ("high", 0.50),
+        ("medium", 0.30),
+        ("low", 0.15),
+    ),
+    confidence_default_tier="thin",
+    market_ranking_rules=(
+        MarketRankingRule(
+            side="over",
+            sort_by=("line", "price_sort_key"),
+            ascending=(True, False),
+        ),
+        MarketRankingRule(
+            side="under",
+            sort_by=("line", "price_sort_key"),
+            ascending=(False, False),
+        ),
+    ),
+    edge_tie_preference="over",
+    pick_type_order=("official", "lean", "pass"),
+    postable_limits=PostablePickLimits(
+        max_official=4,
+        max_leans=2,
+    ),
+)

--- a/MLB/tests/odds/test_policy.py
+++ b/MLB/tests/odds/test_policy.py
@@ -1,0 +1,88 @@
+import pandas as pd
+
+from odds.policy import (
+    DEFAULT_MLB_PITCHER_STRIKEOUT_POLICY,
+    MarketRankingRule,
+    PickRankingPolicy,
+    PostablePickLimits,
+)
+
+
+def test_default_policy_preserves_thresholds_and_caps():
+    policy = DEFAULT_MLB_PITCHER_STRIKEOUT_POLICY
+
+    assert policy.classify_pick_type(0.75) == "official"
+    assert policy.classify_pick_type(0.40) == "lean"
+    assert policy.classify_pick_type(0.39) == "pass"
+    assert policy.classify_confidence_tier(0.50) == "high"
+    assert policy.classify_confidence_tier(0.30) == "medium"
+    assert policy.classify_confidence_tier(0.15) == "low"
+    assert policy.classify_confidence_tier(0.14) == "thin"
+
+    limits = policy.resolved_postable_limits()
+    assert limits.max_official == 4
+    assert limits.max_leans == 2
+
+
+def test_default_policy_preserves_market_tie_breakers():
+    policy = DEFAULT_MLB_PITCHER_STRIKEOUT_POLICY
+    player_df = pd.DataFrame(
+        [
+            {"side_norm": "over", "line": 5.5, "price_sort_key": -120},
+            {"side_norm": "over", "line": 5.5, "price_sort_key": 100},
+            {"side_norm": "over", "line": 6.5, "price_sort_key": 150},
+            {"side_norm": "under", "line": 5.5, "price_sort_key": -110},
+            {"side_norm": "under", "line": 6.5, "price_sort_key": -125},
+            {"side_norm": "under", "line": 6.5, "price_sort_key": 105},
+        ]
+    )
+
+    best_over = policy.select_best_market(player_df, "over")
+    best_under = policy.select_best_market(player_df, "under")
+
+    assert best_over["line"] == 5.5
+    assert best_over["price_sort_key"] == 100
+    assert best_under["line"] == 6.5
+    assert best_under["price_sort_key"] == 105
+
+
+def test_policy_can_change_edge_tie_break_preference_and_postable_caps():
+    policy = PickRankingPolicy(
+        official_edge_threshold=0.75,
+        lean_edge_threshold=0.40,
+        confidence_tier_thresholds=(
+            ("high", 0.50),
+            ("medium", 0.30),
+            ("low", 0.15),
+        ),
+        confidence_default_tier="thin",
+        market_ranking_rules=(
+            MarketRankingRule(
+                side="over",
+                sort_by=("line", "price_sort_key"),
+                ascending=(True, False),
+            ),
+            MarketRankingRule(
+                side="under",
+                sort_by=("line", "price_sort_key"),
+                ascending=(False, False),
+            ),
+        ),
+        edge_tie_preference="under",
+        pick_type_order=("official", "lean", "pass"),
+        postable_limits=PostablePickLimits(max_official=2, max_leans=1),
+    )
+    best_over = pd.Series({"line": 5.5, "bookmaker": "DraftKings"})
+    best_under = pd.Series({"line": 6.5, "bookmaker": "FanDuel"})
+
+    chosen = policy.choose_pick_side(
+        best_over=best_over,
+        best_under=best_under,
+        predicted=6.0,
+    )
+    limits = policy.resolved_postable_limits()
+
+    assert chosen["pick_side"] == "under"
+    assert chosen["edge"] == 0.5
+    assert limits.max_official == 2
+    assert limits.max_leans == 1


### PR DESCRIPTION
This PR extracts pick-ranking behavior from create_picks.py into a dedicated policy layer so thresholds, tie-breakers, sort order, and postable caps are configurable instead of being embedded as local constants and logic.

What Changed

Added MLB/src/odds/policy.py with a PickRankingPolicy and the default MLB pitcher strikeout policy.
Updated MLB/src/odds/create_picks.py to delegate market selection, pick classification, confidence tiers, final ranking, and postable limits to the policy.
Added MLB/tests/odds/test_policy.py to lock in the default policy behavior and verify the policy layer is configurable.
Why

This keeps current MLB strikeout behavior intact while making it much easier to support new props, sportsbooks, and posting styles without continuing to hardcode ranking rules in one module.

Validation

Targeted odds tests passed, including the existing create_picks suite and the new policy tests.