### PR TITLE
untangle pitcher-k specifics from daily orchestration

### DIFF
--- a/MLB/src/jobs/run_daily_card.py
+++ b/MLB/src/jobs/run_daily_card.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from typing import Callable
 
 import pandas as pd
 import xgboost as xgb
@@ -40,6 +41,9 @@ OUTPUT_DIR = DATA_DIR / "outputs"
 PROJECTIONS_DIR = OUTPUT_DIR / "projections"
 EDGES_DIR = OUTPUT_DIR / "edges"
 PICKS_DIR = OUTPUT_DIR / "picks"
+
+BuildPicksFn = Callable[[pd.DataFrame], pd.DataFrame]
+FilterPostablePicksFn = Callable[[pd.DataFrame], pd.DataFrame]
 
 
 def ensure_output_dirs() -> None:
@@ -137,8 +141,24 @@ def save_outputs(
     post_df.to_csv(PICKS_DIR / "today_postable_picks.csv", index=False)
 
 
-def run_daily_card() -> tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame, pd.DataFrame]:
+def run_daily_card(
+    *,
+    market: str = PITCHER_K_PROP_MARKET,
+    build_picks_fn: BuildPicksFn | None = None,
+    filter_postable_picks_fn: FilterPostablePicksFn | None = None,
+) -> tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame, pd.DataFrame]:
     ensure_output_dirs()
+
+    if build_picks_fn is None:
+        build_picks_fn = build_daily_picks
+
+    if filter_postable_picks_fn is None:
+        def filter_postable_picks_fn(picks_df: pd.DataFrame) -> pd.DataFrame:
+            return filter_postable_picks(
+                picks_df,
+                max_official=3,
+                max_leans=1,
+            )
 
     starters_df = get_today_starters_df()
     validate_starters_contract(starters_df)
@@ -155,13 +175,13 @@ def run_daily_card() -> tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame, pd.DataF
     if today_preds.empty:
         raise ValueError("No today predictions were generated.")
 
-    joined_df, _ = run_edge_pipeline(today_preds, PITCHER_K_PROP_MARKET)
+    joined_df, _ = run_edge_pipeline(today_preds, market)
     validate_joined_odds_contract(joined_df)
 
-    picks_df = build_daily_picks(joined_df)
+    picks_df = build_picks_fn(joined_df)
     validate_final_picks_contract(picks_df)
 
-    post_df = filter_postable_picks(picks_df, max_official=3, max_leans=1)
+    post_df = filter_postable_picks_fn(picks_df)
     validate_final_picks_contract(post_df)
 
     save_outputs(

--- a/MLB/src/odds/run_edges.py
+++ b/MLB/src/odds/run_edges.py
@@ -2,13 +2,16 @@ from __future__ import annotations
 
 import pandas as pd
 
-from .odds_api import fetch_all_player_props 
+from .odds_api import fetch_all_player_props
 from .normalize import odds_json_to_dataframe
 from .compare import join_projections_to_odds, best_over_edges
-from pitcher_k.config import PITCHER_K_PROP_MARKET
 
-def run_edge_pipeline(projections: pd.DataFrame, market: str,) -> pd.DataFrame:
-    raw_events = fetch_all_player_props(market=PITCHER_K_PROP_MARKET)
+
+def run_edge_pipeline(
+    projections: pd.DataFrame,
+    market: str,
+) -> tuple[pd.DataFrame, pd.DataFrame]:
+    raw_events = fetch_all_player_props(market=market)
     odds_df = odds_json_to_dataframe(raw_events)
 
     if odds_df.empty:

--- a/MLB/tests/jobs/test_run_daily_card.py
+++ b/MLB/tests/jobs/test_run_daily_card.py
@@ -2,6 +2,7 @@ import pandas as pd
 import pytest
 
 from jobs import run_daily_card as daily_card
+from pitcher_k.config import PITCHER_K_PROP_MARKET
 
 
 def test_run_daily_card_writes_outputs_with_mocked_dependencies(monkeypatch, tmp_path):
@@ -97,7 +98,11 @@ def test_run_daily_card_writes_outputs_with_mocked_dependencies(monkeypatch, tmp
         "build_today_predictions",
         lambda starters_df, pitcher_games, model: today_preds,
     )
-    monkeypatch.setattr(daily_card, "run_edge_pipeline", lambda preds, market: (joined_df, joined_df),)
+    def fake_run_edge_pipeline(preds, market):
+        assert market == PITCHER_K_PROP_MARKET
+        return joined_df, joined_df
+
+    monkeypatch.setattr(daily_card, "run_edge_pipeline", fake_run_edge_pipeline)
     monkeypatch.setattr(daily_card, "build_daily_picks", lambda joined: picks_df)
     monkeypatch.setattr(
         daily_card,
@@ -140,6 +145,130 @@ def test_run_daily_card_writes_outputs_with_mocked_dependencies(monkeypatch, tmp
     assert len(loaded_post) == 1
     assert loaded_post.loc[0, "player_name"] == "Jacob deGrom"
     assert loaded_post.loc[0, "pick_type"] == "official"
+
+
+def test_run_daily_card_allows_explicit_market_and_workflow_behavior(monkeypatch, tmp_path):
+    starters_df = pd.DataFrame(
+        [
+            {
+                "game_date": "2026-04-19",
+                "game_pk": 123456,
+                "pitcher": 1,
+                "player_name": "Jacob deGrom",
+                "team": "TEX",
+                "opponent": "SEA",
+                "home_team": "TEX",
+                "away_team": "SEA",
+                "is_home": 1,
+                "p_throws": "R",
+            }
+        ]
+    )
+
+    pitcher_games = pd.DataFrame(
+        [
+            {
+                "game_date": "2026-04-18",
+                "game_pk": 111111,
+                "pitcher": 1,
+                "player_name": "Jacob deGrom",
+                "pitching_team": "TEX",
+                "opponent_team": "SEA",
+                "opp_strikeouts_per_game_last10": 9.4,
+                "opp_k_rate_last10": 0.255,
+            }
+        ]
+    )
+
+    today_preds = pd.DataFrame(
+        [
+            {
+                "player_name": "Jacob deGrom",
+                "team": "TEX",
+                "opponent": "SEA",
+                "predicted_strikeouts": 6.8,
+            }
+        ]
+    )
+
+    joined_df = pd.DataFrame(
+        [
+            {
+                "player_name_proj": "Jacob deGrom",
+                "team": "TEX",
+                "opponent": "SEA",
+                "predicted_strikeouts": 6.8,
+                "bookmaker": "DraftKings",
+                "side": "Over",
+                "line": 5.5,
+                "price": -120,
+            }
+        ]
+    )
+
+    picks_df = pd.DataFrame(
+        [
+            {
+                "player_name": "Jacob deGrom",
+                "team": "TEX",
+                "opponent": "SEA",
+                "predicted_strikeouts": 6.8,
+                "book": "DraftKings",
+                "pick_side": "over",
+                "line": 5.5,
+                "price": -120,
+                "edge": 1.3,
+                "implied_probability": 120 / 220,
+                "value_score": 1.3 * (1 - (120 / 220)),
+                "confidence_tier": "medium",
+                "pick_type": "official",
+            }
+        ]
+    )
+    post_df = picks_df.copy()
+
+    monkeypatch.setattr(daily_card, "get_today_starters_df", lambda: starters_df)
+    monkeypatch.setattr(daily_card, "load_pitcher_games_artifact", lambda: pitcher_games)
+    monkeypatch.setattr(daily_card, "load_model_artifact", lambda: "fake_model")
+    monkeypatch.setattr(daily_card, "load_model_metadata", lambda: {"target": "strikeouts"})
+    monkeypatch.setattr(
+        daily_card,
+        "build_today_predictions",
+        lambda starters_df, pitcher_games, model: today_preds,
+    )
+    monkeypatch.setattr(daily_card, "DATA_DIR", tmp_path / "data")
+    monkeypatch.setattr(daily_card, "OUTPUT_DIR", tmp_path / "data" / "outputs")
+    monkeypatch.setattr(daily_card, "PROJECTIONS_DIR", tmp_path / "data" / "outputs" / "projections")
+    monkeypatch.setattr(daily_card, "EDGES_DIR", tmp_path / "data" / "outputs" / "edges")
+    monkeypatch.setattr(daily_card, "PICKS_DIR", tmp_path / "data" / "outputs" / "picks")
+    monkeypatch.setattr(daily_card, "save_today_starters_csv", lambda df, output_dir=None, filename=None: tmp_path / "today_starters.csv")
+
+    custom_market = "custom_market"
+    calls = {}
+
+    def fake_run_edge_pipeline(preds, market):
+        calls["market"] = market
+        return joined_df, joined_df
+
+    def fake_build_picks(joined):
+        calls["build_picks_joined"] = joined.copy()
+        return picks_df
+
+    def fake_filter_postable(picks):
+        calls["filter_postable_picks"] = picks.copy()
+        return post_df
+
+    monkeypatch.setattr(daily_card, "run_edge_pipeline", fake_run_edge_pipeline)
+
+    daily_card.run_daily_card(
+        market=custom_market,
+        build_picks_fn=fake_build_picks,
+        filter_postable_picks_fn=fake_filter_postable,
+    )
+
+    assert calls["market"] == custom_market
+    pd.testing.assert_frame_equal(calls["build_picks_joined"], joined_df)
+    pd.testing.assert_frame_equal(calls["filter_postable_picks"], picks_df)
 
 
 def test_run_daily_card_raises_when_today_predictions_are_empty(monkeypatch, tmp_path):


### PR DESCRIPTION
This PR removes pitcher-K-specific hidden dependencies from shared orchestration code by passing market and workflow behavior explicitly through the daily card pipeline.

What changed

run_edge_pipeline(...) now uses its explicit market argument instead of importing PITCHER_K_PROP_MARKET internally.
run_daily_card(...) now accepts explicit workflow behavior inputs for market selection, pick building, and postable filtering.
The default daily MLB pitcher strikeouts behavior is preserved, so existing usage continues to work unchanged.
Tests were updated to verify both the existing default flow and the new explicit handoff behavior.
Why

This makes the orchestration layers more reusable for future prop workflows, reduces hidden coupling to pitcher-K config, and keeps the current pitcher strikeouts workflow stable while we move toward workflow-spec-driven pipelines.

Validation

MLB/tests/odds/test_run_edges.py
MLB/tests/jobs/test_run_daily_card.py