### PR TITLE
Introduces workflow for props independent of pitcher-k

### DIFF
--- a/MLB/src/common/workflows.py
+++ b/MLB/src/common/workflows.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Callable
+
+import pandas as pd
+
+from odds.policy import (
+    DEFAULT_MLB_PITCHER_STRIKEOUT_POLICY,
+    PickRankingPolicy,
+    PostablePickLimits,
+)
+from pitcher_k.config import PITCHER_K_PROP_MARKET
+from pitcher_k.feature_engineering import build_team_context
+from pitcher_k.feature_tomorrow import build_tomorrow_features
+from pitcher_k.predict import predict_on_dataframe
+
+FeatureBuilder = Callable[[pd.DataFrame, pd.DataFrame], pd.DataFrame]
+Predictor = Callable[[object, pd.DataFrame], pd.DataFrame]
+
+
+@dataclass(frozen=True)
+class ProjectionOddsJoinKeys:
+    projection: str
+    odds: str
+
+
+@dataclass(frozen=True)
+class ModelingWorkflowSpec:
+    sport: str
+    participant_key: str
+    market_key: str
+    feature_builder: FeatureBuilder
+    predictor: Predictor
+    projection_odds_join_keys: ProjectionOddsJoinKeys
+    pick_ranking_policy: PickRankingPolicy
+    postable_limits: PostablePickLimits = field(default_factory=PostablePickLimits)
+
+    def resolved_postable_limits(self) -> PostablePickLimits:
+        return self.postable_limits
+
+
+def build_mlb_pitcher_strikeout_features(
+    starters_df: pd.DataFrame,
+    pitcher_games: pd.DataFrame,
+) -> pd.DataFrame:
+    as_of_date = starters_df["game_date"].min()
+    team_context = build_team_context(pitcher_games, as_of_date=as_of_date)
+    return build_tomorrow_features(
+        slate_df=starters_df,
+        pitcher_games=pitcher_games,
+        team_context=team_context,
+    )
+
+
+MLB_PITCHER_STRIKEOUT_WORKFLOW = ModelingWorkflowSpec(
+    sport="MLB",
+    participant_key="player_name",
+    market_key=PITCHER_K_PROP_MARKET,
+    feature_builder=build_mlb_pitcher_strikeout_features,
+    predictor=predict_on_dataframe,
+    projection_odds_join_keys=ProjectionOddsJoinKeys(
+        projection="player_name_norm",
+        odds="player_name_norm",
+    ),
+    pick_ranking_policy=DEFAULT_MLB_PITCHER_STRIKEOUT_POLICY,
+    postable_limits=PostablePickLimits(
+        max_official=3,
+        max_leans=1,
+    ),
+)

--- a/MLB/src/jobs/run_daily_card.py
+++ b/MLB/src/jobs/run_daily_card.py
@@ -10,10 +10,6 @@ import pandas as pd
 import xgboost as xgb
 
 from starters.today_starters import get_today_starters_df, save_today_starters_csv
-from pitcher_k.feature_engineering import build_team_context
-from pitcher_k.feature_tomorrow import build_tomorrow_features
-from pitcher_k.predict import predict_on_dataframe
-from pitcher_k.config import PITCHER_K_PROP_MARKET
 
 from odds.run_edges import run_edge_pipeline
 from odds.create_picks import build_daily_picks, filter_postable_picks
@@ -25,6 +21,7 @@ from common.contracts import (
     assert_non_empty,
     require_columns,
 )
+from common.workflows import MLB_PITCHER_STRIKEOUT_WORKFLOW, ModelingWorkflowSpec
 
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
 DATA_DIR = PROJECT_ROOT / "data"
@@ -101,22 +98,30 @@ def load_model_metadata() -> dict:
 
 
 def build_today_predictions(starters_df: pd.DataFrame, pitcher_games: pd.DataFrame, model):
+    return build_today_predictions_for_workflow(
+        starters_df=starters_df,
+        pitcher_games=pitcher_games,
+        model=model,
+        workflow=MLB_PITCHER_STRIKEOUT_WORKFLOW,
+    )
+
+
+def build_today_predictions_for_workflow(
+    *,
+    starters_df: pd.DataFrame,
+    pitcher_games: pd.DataFrame,
+    model,
+    workflow: ModelingWorkflowSpec,
+):
     validate_starters_contract(starters_df)
     validate_pitcher_games_contract(pitcher_games)
 
-    as_of_date = starters_df["game_date"].min()
-    team_context = build_team_context(pitcher_games, as_of_date=as_of_date)
-
-    today_features = build_tomorrow_features(
-        slate_df=starters_df,
-        pitcher_games=pitcher_games,
-        team_context=team_context,
-    )
+    today_features = workflow.feature_builder(starters_df, pitcher_games)
 
     if today_features.empty:
         return today_features
 
-    today_preds = predict_on_dataframe(model, today_features)
+    today_preds = workflow.predictor(model, today_features)
     assert_non_empty(today_preds, "today_preds")
     require_columns(
         today_preds,
@@ -143,21 +148,29 @@ def save_outputs(
 
 def run_daily_card(
     *,
-    market: str = PITCHER_K_PROP_MARKET,
+    workflow: ModelingWorkflowSpec = MLB_PITCHER_STRIKEOUT_WORKFLOW,
+    market: str | None = None,
     build_picks_fn: BuildPicksFn | None = None,
     filter_postable_picks_fn: FilterPostablePicksFn | None = None,
 ) -> tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame, pd.DataFrame]:
     ensure_output_dirs()
 
     if build_picks_fn is None:
-        build_picks_fn = build_daily_picks
+        def build_picks_fn(joined_df: pd.DataFrame) -> pd.DataFrame:
+            return build_daily_picks(
+                joined_df,
+                policy=workflow.pick_ranking_policy,
+            )
 
     if filter_postable_picks_fn is None:
+        postable_limits = workflow.resolved_postable_limits()
+
         def filter_postable_picks_fn(picks_df: pd.DataFrame) -> pd.DataFrame:
             return filter_postable_picks(
                 picks_df,
-                max_official=3,
-                max_leans=1,
+                max_official=postable_limits.max_official,
+                max_leans=postable_limits.max_leans,
+                policy=workflow.pick_ranking_policy,
             )
 
     starters_df = get_today_starters_df()
@@ -166,16 +179,24 @@ def run_daily_card(
     model = load_model_artifact()
     load_model_metadata()
 
-    today_preds = build_today_predictions(
+    today_preds = build_today_predictions_for_workflow(
         starters_df=starters_df,
         pitcher_games=pitcher_games,
         model=model,
+        workflow=workflow,
     )
 
     if today_preds.empty:
         raise ValueError("No today predictions were generated.")
 
-    joined_df, _ = run_edge_pipeline(today_preds, market)
+    selected_market = market or workflow.market_key
+    joined_df, _ = run_edge_pipeline(
+        today_preds,
+        selected_market,
+        participant_key=workflow.participant_key,
+        projection_join_key=workflow.projection_odds_join_keys.projection,
+        odds_join_key=workflow.projection_odds_join_keys.odds,
+    )
     validate_joined_odds_contract(joined_df)
 
     picks_df = build_picks_fn(joined_df)

--- a/MLB/src/odds/compare.py
+++ b/MLB/src/odds/compare.py
@@ -7,38 +7,61 @@ import pandas as pd
 from .normalize import normalize_player_name
 
 
-def prepare_projection_df(projections: pd.DataFrame) -> pd.DataFrame:
+def prepare_projection_df(
+    projections: pd.DataFrame,
+    *,
+    participant_key: str = "player_name",
+    projection_join_key: str = "player_name_norm",
+) -> pd.DataFrame:
     require_columns(
         projections,
-        ["player_name", "predicted_strikeouts"],
+        [participant_key, "predicted_strikeouts"],
         "projections_df",
     )
     assert_non_empty(projections, "projections_df")
 
     df = projections.copy()
-    df["player_name_norm"] = df["player_name"].apply(normalize_player_name)
+
+    if projection_join_key not in df.columns:
+        if participant_key == "player_name" and projection_join_key == "player_name_norm":
+            df[projection_join_key] = df[participant_key].apply(normalize_player_name)
+        else:
+            raise ValueError(
+                "projections_df is missing the configured join key "
+                f"'{projection_join_key}'."
+            )
+
     return df
 
 
 def join_projections_to_odds(
     projections: pd.DataFrame,
     odds_df: pd.DataFrame,
+    *,
+    participant_key: str = "player_name",
+    projection_join_key: str = "player_name_norm",
+    odds_join_key: str = "player_name_norm",
 ) -> pd.DataFrame:
-    proj = prepare_projection_df(projections)
-    
+    proj = prepare_projection_df(
+        projections,
+        participant_key=participant_key,
+        projection_join_key=projection_join_key,
+    )
+
     if odds_df.empty:
         return pd.DataFrame()
     require_columns(
         odds_df,
-        ["player_name_norm", "bookmaker", "side", "line", "price"],
+        [odds_join_key, "bookmaker", "side", "line", "price"],
         "odds_df",)
 
     merged = proj.merge(
         odds_df,
-        on="player_name_norm",
+        left_on=projection_join_key,
+        right_on=odds_join_key,
         how="inner",
         suffixes=("_proj", "_odds"),)
-    
+
     if merged.empty:
         return merged
 
@@ -53,11 +76,15 @@ def join_projections_to_odds(
     return merged
 
 
-def best_over_edges(joined: pd.DataFrame) -> pd.DataFrame:
+def best_over_edges(
+    joined: pd.DataFrame,
+    *,
+    group_key: str = "player_name_proj",
+) -> pd.DataFrame:
     if joined.empty:
         return pd.DataFrame()
 
-    require_columns(joined, ["side", "edge", "player_name_proj"], "joined_odds_df")
+    require_columns(joined, ["side", "edge", group_key], "joined_odds_df")
 
     over_df = joined[joined["side"].fillna("").str.lower() == "over"].copy()
     if over_df.empty:
@@ -66,7 +93,7 @@ def best_over_edges(joined: pd.DataFrame) -> pd.DataFrame:
     over_df = over_df.sort_values("edge", ascending=False)
 
     best = (
-        over_df.groupby("player_name_proj", as_index=False)
+        over_df.groupby(group_key, as_index=False)
         .first()
         .sort_values("edge", ascending=False)
         .reset_index(drop=True)

--- a/MLB/src/odds/run_edges.py
+++ b/MLB/src/odds/run_edges.py
@@ -10,6 +10,10 @@ from .compare import join_projections_to_odds, best_over_edges
 def run_edge_pipeline(
     projections: pd.DataFrame,
     market: str,
+    *,
+    participant_key: str = "player_name",
+    projection_join_key: str = "player_name_norm",
+    odds_join_key: str = "player_name_norm",
 ) -> tuple[pd.DataFrame, pd.DataFrame]:
     raw_events = fetch_all_player_props(market=market)
     odds_df = odds_json_to_dataframe(raw_events)
@@ -17,10 +21,16 @@ def run_edge_pipeline(
     if odds_df.empty:
         return pd.DataFrame(), pd.DataFrame()
 
-    joined = join_projections_to_odds(projections, odds_df)
+    joined = join_projections_to_odds(
+        projections,
+        odds_df,
+        participant_key=participant_key,
+        projection_join_key=projection_join_key,
+        odds_join_key=odds_join_key,
+    )
 
     if joined.empty:
         return joined, pd.DataFrame()
 
-    best_edges = best_over_edges(joined)
+    best_edges = best_over_edges(joined, group_key=f"{participant_key}_proj")
     return joined, best_edges

--- a/MLB/tests/jobs/test_run_daily_card.py
+++ b/MLB/tests/jobs/test_run_daily_card.py
@@ -2,6 +2,11 @@ import pandas as pd
 import pytest
 
 from jobs import run_daily_card as daily_card
+from common.workflows import ModelingWorkflowSpec, ProjectionOddsJoinKeys
+from odds.policy import (
+    DEFAULT_MLB_PITCHER_STRIKEOUT_POLICY,
+    PostablePickLimits,
+)
 from pitcher_k.config import PITCHER_K_PROP_MARKET
 
 
@@ -95,19 +100,20 @@ def test_run_daily_card_writes_outputs_with_mocked_dependencies(monkeypatch, tmp
     )
     monkeypatch.setattr(
         daily_card,
-        "build_today_predictions",
-        lambda starters_df, pitcher_games, model: today_preds,
+        "build_today_predictions_for_workflow",
+        lambda *, starters_df, pitcher_games, model, workflow: today_preds,
     )
-    def fake_run_edge_pipeline(preds, market):
+
+    def fake_run_edge_pipeline(preds, market, **kwargs):
         assert market == PITCHER_K_PROP_MARKET
         return joined_df, joined_df
 
     monkeypatch.setattr(daily_card, "run_edge_pipeline", fake_run_edge_pipeline)
-    monkeypatch.setattr(daily_card, "build_daily_picks", lambda joined: picks_df)
+    monkeypatch.setattr(daily_card, "build_daily_picks", lambda joined, policy: picks_df)
     monkeypatch.setattr(
         daily_card,
         "filter_postable_picks",
-        lambda picks, max_official=3, max_leans=1: post_df,
+        lambda picks, max_official=3, max_leans=1, policy=None: post_df,
     )
 
     monkeypatch.setattr(daily_card, "DATA_DIR", tmp_path / "data")
@@ -233,8 +239,8 @@ def test_run_daily_card_allows_explicit_market_and_workflow_behavior(monkeypatch
     monkeypatch.setattr(daily_card, "load_model_metadata", lambda: {"target": "strikeouts"})
     monkeypatch.setattr(
         daily_card,
-        "build_today_predictions",
-        lambda starters_df, pitcher_games, model: today_preds,
+        "build_today_predictions_for_workflow",
+        lambda *, starters_df, pitcher_games, model, workflow: today_preds,
     )
     monkeypatch.setattr(daily_card, "DATA_DIR", tmp_path / "data")
     monkeypatch.setattr(daily_card, "OUTPUT_DIR", tmp_path / "data" / "outputs")
@@ -246,8 +252,9 @@ def test_run_daily_card_allows_explicit_market_and_workflow_behavior(monkeypatch
     custom_market = "custom_market"
     calls = {}
 
-    def fake_run_edge_pipeline(preds, market):
+    def fake_run_edge_pipeline(preds, market, **kwargs):
         calls["market"] = market
+        calls["join_kwargs"] = kwargs
         return joined_df, joined_df
 
     def fake_build_picks(joined):
@@ -267,6 +274,11 @@ def test_run_daily_card_allows_explicit_market_and_workflow_behavior(monkeypatch
     )
 
     assert calls["market"] == custom_market
+    assert calls["join_kwargs"] == {
+        "participant_key": "player_name",
+        "projection_join_key": "player_name_norm",
+        "odds_join_key": "player_name_norm",
+    }
     pd.testing.assert_frame_equal(calls["build_picks_joined"], joined_df)
     pd.testing.assert_frame_equal(calls["filter_postable_picks"], picks_df)
 
@@ -314,8 +326,8 @@ def test_run_daily_card_raises_when_today_predictions_are_empty(monkeypatch, tmp
     )
     monkeypatch.setattr(
         daily_card,
-        "build_today_predictions",
-        lambda starters_df, pitcher_games, model: pd.DataFrame(),
+        "build_today_predictions_for_workflow",
+        lambda *, starters_df, pitcher_games, model, workflow: pd.DataFrame(),
     )
 
     monkeypatch.setattr(daily_card, "DATA_DIR", tmp_path / "data")
@@ -360,6 +372,144 @@ def test_run_daily_card_raises_when_pitcher_games_artifact_is_missing(monkeypatc
 
     with pytest.raises(FileNotFoundError, match="Missing pitcher_games artifact"):
         daily_card.run_daily_card()
+
+
+def test_run_daily_card_uses_workflow_spec_for_market_policy_and_limits(monkeypatch, tmp_path):
+    starters_df = pd.DataFrame(
+        [
+            {
+                "game_date": "2026-04-19",
+                "game_pk": 123456,
+                "pitcher": 1,
+                "player_name": "Jacob deGrom",
+                "team": "TEX",
+                "opponent": "SEA",
+                "home_team": "TEX",
+                "away_team": "SEA",
+                "is_home": 1,
+                "p_throws": "R",
+            }
+        ]
+    )
+    pitcher_games = pd.DataFrame(
+        [
+            {
+                "game_date": "2026-04-18",
+                "game_pk": 111111,
+                "pitcher": 1,
+                "player_name": "Jacob deGrom",
+                "pitching_team": "TEX",
+                "opponent_team": "SEA",
+                "opp_strikeouts_per_game_last10": 9.4,
+                "opp_k_rate_last10": 0.255,
+            }
+        ]
+    )
+    today_preds = pd.DataFrame(
+        [
+            {
+                "player_name": "Jacob deGrom",
+                "team": "TEX",
+                "opponent": "SEA",
+                "predicted_strikeouts": 6.8,
+                "lower_bound": 5.8,
+                "upper_bound": 7.8,
+                "std_dev": 1.0,
+            }
+        ]
+    )
+    joined_df = pd.DataFrame(
+        [
+            {
+                "player_name_proj": "Jacob deGrom",
+                "team": "TEX",
+                "opponent": "SEA",
+                "predicted_strikeouts": 6.8,
+                "bookmaker": "DraftKings",
+                "side": "Over",
+                "line": 5.5,
+                "price": -120,
+            }
+        ]
+    )
+    picks_df = pd.DataFrame(
+        [
+            {
+                "player_name": "Jacob deGrom",
+                "book": "DraftKings",
+                "pick_side": "over",
+                "line": 5.5,
+                "price": -120,
+                "edge": 1.3,
+                "pick_type": "official",
+                "implied_probability": 120 / 220,
+                "value_score": 1.3 * (1 - (120 / 220)),
+                "confidence_tier": "medium",
+            }
+        ]
+    )
+    post_df = picks_df.copy()
+    calls: dict[str, object] = {}
+
+    workflow = ModelingWorkflowSpec(
+        sport="MLB",
+        participant_key="player_name",
+        market_key="workflow_market",
+        feature_builder=lambda starters, history: starters,
+        predictor=lambda model, features: features,
+        projection_odds_join_keys=ProjectionOddsJoinKeys(
+            projection="player_name_norm",
+            odds="player_name_norm",
+        ),
+        pick_ranking_policy=DEFAULT_MLB_PITCHER_STRIKEOUT_POLICY,
+        postable_limits=PostablePickLimits(max_official=1, max_leans=0),
+    )
+
+    monkeypatch.setattr(daily_card, "get_today_starters_df", lambda: starters_df)
+    monkeypatch.setattr(daily_card, "load_pitcher_games_artifact", lambda: pitcher_games)
+    monkeypatch.setattr(daily_card, "load_model_artifact", lambda: "fake_model")
+    monkeypatch.setattr(daily_card, "load_model_metadata", lambda: {"target": "strikeouts"})
+    monkeypatch.setattr(
+        daily_card,
+        "build_today_predictions_for_workflow",
+        lambda *, starters_df, pitcher_games, model, workflow: today_preds,
+    )
+    monkeypatch.setattr(daily_card, "DATA_DIR", tmp_path / "data")
+    monkeypatch.setattr(daily_card, "OUTPUT_DIR", tmp_path / "data" / "outputs")
+    monkeypatch.setattr(daily_card, "PROJECTIONS_DIR", tmp_path / "data" / "outputs" / "projections")
+    monkeypatch.setattr(daily_card, "EDGES_DIR", tmp_path / "data" / "outputs" / "edges")
+    monkeypatch.setattr(daily_card, "PICKS_DIR", tmp_path / "data" / "outputs" / "picks")
+    monkeypatch.setattr(daily_card, "save_today_starters_csv", lambda df, output_dir=None, filename=None: tmp_path / "today_starters.csv")
+
+    def fake_run_edge_pipeline(preds, market, **kwargs):
+        calls["market"] = market
+        calls["join_kwargs"] = kwargs
+        return joined_df, joined_df
+
+    def fake_build_daily_picks(df, policy):
+        calls["build_policy"] = policy
+        return picks_df
+
+    def fake_filter_postable_picks(df, max_official, max_leans, policy):
+        calls["filter_limits"] = (max_official, max_leans)
+        calls["filter_policy"] = policy
+        return post_df
+
+    monkeypatch.setattr(daily_card, "run_edge_pipeline", fake_run_edge_pipeline)
+    monkeypatch.setattr(daily_card, "build_daily_picks", fake_build_daily_picks)
+    monkeypatch.setattr(daily_card, "filter_postable_picks", fake_filter_postable_picks)
+
+    daily_card.run_daily_card(workflow=workflow)
+
+    assert calls["market"] == "workflow_market"
+    assert calls["join_kwargs"] == {
+        "participant_key": "player_name",
+        "projection_join_key": "player_name_norm",
+        "odds_join_key": "player_name_norm",
+    }
+    assert calls["build_policy"] is workflow.pick_ranking_policy
+    assert calls["filter_policy"] is workflow.pick_ranking_policy
+    assert calls["filter_limits"] == (1, 0)
 
 
 def test_load_model_metadata_reads_matching_file_from_selected_artifact_dir(tmp_path, monkeypatch, capsys):

--- a/MLB/tests/odds/test_compare.py
+++ b/MLB/tests/odds/test_compare.py
@@ -28,6 +28,26 @@ def test_prepare_projection_df_adds_normalized_name():
     assert result.loc[0, "player_name_norm"] == "jacob degrom"
 
 
+def test_prepare_projection_df_respects_precomputed_join_key():
+    projections = pd.DataFrame(
+        [
+            {
+                "player_name": "Jacob deGrom",
+                "participant_norm": "jacob degrom",
+                "predicted_strikeouts": 6.78,
+            }
+        ]
+    )
+
+    result = prepare_projection_df(
+        projections,
+        participant_key="player_name",
+        projection_join_key="participant_norm",
+    )
+
+    assert result.loc[0, "participant_norm"] == "jacob degrom"
+
+
 def test_join_projections_to_odds_computes_edge():
     projections = pd.DataFrame(
         [
@@ -105,6 +125,42 @@ def test_join_projections_to_odds_matches_on_normalized_name():
     )
 
     joined = join_projections_to_odds(projections, odds_df)
+
+    assert len(joined) == 1
+    assert joined.iloc[0]["player_name_proj"] == "Jacob deGrom"
+
+
+def test_join_projections_to_odds_accepts_configured_join_keys():
+    projections = pd.DataFrame(
+        [
+            {
+                "player_name": "Jacob deGrom",
+                "participant_norm": "jacob degrom",
+                "predicted_strikeouts": 6.78,
+            }
+        ]
+    )
+
+    odds_df = pd.DataFrame(
+        [
+            {
+                "player_name": "Jacob Degrom",
+                "odds_participant_norm": "jacob degrom",
+                "bookmaker": "DraftKings",
+                "side": "Over",
+                "line": 6.5,
+                "price": -120,
+            }
+        ]
+    )
+
+    joined = join_projections_to_odds(
+        projections,
+        odds_df,
+        participant_key="player_name",
+        projection_join_key="participant_norm",
+        odds_join_key="odds_participant_norm",
+    )
 
     assert len(joined) == 1
     assert joined.iloc[0]["player_name_proj"] == "Jacob deGrom"

--- a/README.md
+++ b/README.md
@@ -92,12 +92,13 @@ Artifacts are written to `MLB/data/artifacts/_staging/`, validated, then promote
 1. pull today's probable starters from the MLB Stats API
 2. validate and normalize the starter slate
 3. load the most recent saved model and pitcher-game history
-4. build today features for the current slate
-5. generate pitcher strikeout projections
-6. fetch market data from The Odds API
-7. join projections to normalized odds rows
-8. choose the best market per pitcher according to the configured pick policy
-9. classify picks and export a smaller postable subset
+4. resolve the active workflow spec for the prop
+5. build today features for the current slate
+6. generate pitcher strikeout projections
+7. fetch market data from The Odds API
+8. join projections to normalized odds rows
+9. choose the best market per pitcher according to the configured pick policy
+10. classify picks and export a smaller postable subset
 
 Outputs are written to:
 
@@ -117,6 +118,20 @@ Outputs are written to:
 - final picks output
 
 These checks enforce required columns, non-null expectations, uniqueness, and boolean-like fields so pipeline failures happen early and loudly.
+
+### 3.5 Workflow spec
+
+`MLB/src/common/workflows.py` defines the first lightweight workflow spec for MLB pitcher strikeouts. It describes:
+
+- sport
+- participant key
+- market key
+- feature builder
+- predictor
+- projection/odds join keys
+- pick-ranking policy
+
+The daily card job consumes that spec directly, which keeps the current behavior intact while giving future props a repeatable orchestration shape without introducing a large framework.
 
 ### 4. Odds and pick policy
 


### PR DESCRIPTION
This PR extracts the minimum stable workflow shape from the existing MLB pitcher strikeout pipeline so the daily card path can describe a prop consistently without introducing a large framework.

The first implementation is a single workflow spec for MLB pitcher strikeouts. The daily card job now consumes that spec for workflow-specific behavior while preserving current output behavior.

Closes issue 14.

What Changed

Added a lightweight workflow spec in MLB/src/common/workflows.py
Wired MLB/src/jobs/run_daily_card.py to use the workflow spec
Parameterized projection-to-odds joining in MLB/src/odds/compare.py
Threaded join metadata through MLB/src/odds/run_edges.py
Added tests covering workflow-driven market, join keys, policy, and limits
Updated README.md to document the workflow spec shape
Key Logic

ModelingWorkflowSpec defines:

sport
participant_key
market_key
feature_builder
predictor
projection_odds_join_keys
pick_ranking_policy
postable limits
MLB_PITCHER_STRIKEOUT_WORKFLOW is the first concrete spec and maps directly to the current pitcher strikeout pipeline:

builds pitcher-K features from starters plus pitcher game history
uses the existing predictor
joins projections to odds on normalized player-name keys
uses the existing MLB pitcher strikeout ranking policy
run_daily_card() now resolves workflow behavior from the spec instead of hardcoding pitcher-K orchestration:

builds predictions via the workflow’s feature builder and predictor
defaults market selection from the workflow’s market_key
passes workflow join keys into the odds pipeline
passes workflow policy and postable limits into pick creation/filtering
Odds comparison functions now accept configurable join keys, which keeps current MLB behavior intact but removes the need to copy the orchestration path for a second prop later

Behavior Impact

No intended modeling or pick-ranking behavior changes for MLB pitcher strikeouts
Refactor is intentionally narrow and keeps existing data contracts and output shape in place
Testing

MLB/tests/jobs/test_run_daily_card.py
MLB/tests/odds/test_compare.py
MLB/tests/odds/test_policy.py
MLB/tests/odds/test_create_picks.py