### PR TITLE
Feature/expand model quality instrumentation

### DIFF
--- a/MLB/src/common/contracts.py
+++ b/MLB/src/common/contracts.py
@@ -51,6 +51,19 @@ FINAL_PICKS_REQUIRED_COLUMNS = [
     "confidence_tier",
 ]
 
+HISTORICAL_LINES_REQUIRED_COLUMNS = [
+    "game_date",
+    "player_name",
+    "player_name_norm",
+    "market_key",
+    "bookmaker",
+    "side",
+    "line",
+    "price",
+    "selection_rule",
+    "source",
+]
+
 
 def validate_dataframe_contract(
     df: pd.DataFrame,
@@ -196,4 +209,26 @@ def validate_final_picks_contract(df: pd.DataFrame) -> None:
             "edge",
             "pick_type",
         ],
+    )
+
+
+def validate_historical_lines_contract(df: pd.DataFrame) -> None:
+    validate_dataframe_contract(
+        df,
+        name="historical_lines_df",
+        required_columns=HISTORICAL_LINES_REQUIRED_COLUMNS,
+        non_null_columns=[
+            "game_date",
+            "player_name",
+            "player_name_norm",
+            "market_key",
+            "bookmaker",
+            "side",
+            "line",
+            "price",
+            "selection_rule",
+            "source",
+        ],
+        unique_keys=["game_date", "player_name_norm", "bookmaker", "side"],
+        require_non_empty_frame=False,
     )

--- a/MLB/src/jobs/build_historical_lines_artifact.py
+++ b/MLB/src/jobs/build_historical_lines_artifact.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+from jobs.build_training_artifacts import (
+    LATEST_DIR,
+    PREVIOUS_DIR,
+    RAW_HISTORICAL_LINES_DIR,
+    artifact_paths,
+    ensure_artifact_dirs,
+)
+from odds.historical_lines import build_historical_lines_artifact_df
+
+
+def build_historical_lines_artifact() -> tuple[Path, int]:
+    """
+    Build the curated native historical lines artifact from raw snapshot files.
+    """
+    ensure_artifact_dirs()
+
+    historical_lines_df = build_historical_lines_artifact_df(RAW_HISTORICAL_LINES_DIR)
+    latest_path = artifact_paths(LATEST_DIR)["historical_lines"]
+    previous_path = artifact_paths(PREVIOUS_DIR)["historical_lines"]
+
+    if latest_path.exists():
+        previous_path.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(latest_path, previous_path)
+
+    latest_path.parent.mkdir(parents=True, exist_ok=True)
+    historical_lines_df.to_csv(latest_path, index=False)
+
+    return latest_path, int(len(historical_lines_df))
+
+
+if __name__ == "__main__":
+    output_path, rows = build_historical_lines_artifact()
+    print("Saved native historical lines artifact:")
+    print(f"- path: {output_path}")
+    print(f"- rows: {rows}")

--- a/MLB/src/jobs/build_training_artifacts.py
+++ b/MLB/src/jobs/build_training_artifacts.py
@@ -9,6 +9,8 @@ from pathlib import Path
 import pandas as pd
 
 from common.contracts import validate_pitcher_games_contract, require_columns
+from odds.backtest import run_historical_workflow_backtest, summarize_backtest_for_metadata
+from odds.historical_lines import build_historical_lines_artifact_df, empty_historical_lines_df
 from pitcher_k.evaluate import (
     build_error_bucket_summary,
     build_prediction_results,
@@ -48,7 +50,9 @@ PREVIOUS_DIR = ARTIFACTS_DIR / "previous"
 MODEL_FILENAME = "model.ubj"
 PITCHER_GAMES_FILENAME = "pitcher_games.csv"
 MODEL_DF_FILENAME = "model_df.csv"
+HISTORICAL_LINES_FILENAME = "historical_lines.csv"
 METADATA_FILENAME = "metadata.json"
+RAW_HISTORICAL_LINES_DIR = DATA_DIR / "raw" / "historical_lines"
 
 
 def ensure_artifact_dirs() -> None:
@@ -62,6 +66,7 @@ def artifact_paths(base_dir: Path) -> dict[str, Path]:
         "model": base_dir / MODEL_FILENAME,
         "pitcher_games": base_dir / PITCHER_GAMES_FILENAME,
         "model_df": base_dir / MODEL_DF_FILENAME,
+        "historical_lines": base_dir / HISTORICAL_LINES_FILENAME,
         "metadata": base_dir / METADATA_FILENAME,
     }
 
@@ -112,7 +117,14 @@ def build_historical_pitcher_games() -> pd.DataFrame:
     return pitcher_games
 
 
-def train_pitcher_k_model(pitcher_games: pd.DataFrame):
+def build_native_historical_lines() -> pd.DataFrame:
+    return build_historical_lines_artifact_df(RAW_HISTORICAL_LINES_DIR)
+
+
+def train_pitcher_k_model(
+    pitcher_games: pd.DataFrame,
+    historical_lines_df: pd.DataFrame | None = None,
+):
     model_df = build_model_df(pitcher_games)
     train_df, test_df = time_split(model_df)
     train_output = train_model(train_df, test_df)
@@ -121,6 +133,7 @@ def train_pitcher_k_model(pitcher_games: pd.DataFrame):
         train_df=train_df,
         test_df=test_df,
         train_output=train_output,
+        historical_lines_df=historical_lines_df,
     )
     return train_output["model"], model_df, metadata
 
@@ -136,7 +149,40 @@ def _date_range(df: pd.DataFrame) -> dict[str, str | None]:
     }
 
 
-def _evaluation_metrics(train_output: dict) -> dict:
+def _build_workflow_backtest_summary(
+    *,
+    test_df: pd.DataFrame,
+    y_test: pd.Series,
+    y_pred_test,
+    historical_lines_df: pd.DataFrame | None,
+) -> dict:
+    if historical_lines_df is None or historical_lines_df.empty:
+        return {
+            "available": False,
+            "reason": "historical_market_lines_not_provided",
+            "reproducible_path": "odds.backtest.run_historical_workflow_backtest",
+        }
+
+    projections = test_df[["game_date", "player_name"]].copy()
+    projections["predicted_strikeouts"] = pd.Series(y_pred_test, index=test_df.index).values
+    projections["actual_strikeouts"] = pd.Series(y_test, index=test_df.index).values
+
+    backtest_result = run_historical_workflow_backtest(
+        projections,
+        historical_lines_df,
+        actual_column="actual_strikeouts",
+    )
+    backtest_summary = summarize_backtest_for_metadata(backtest_result)
+    backtest_summary["reproducible_path"] = "odds.backtest.run_historical_workflow_backtest"
+    return backtest_summary
+
+
+def _evaluation_metrics(
+    train_output: dict,
+    *,
+    test_df: pd.DataFrame,
+    historical_lines_df: pd.DataFrame | None = None,
+) -> dict:
     y_train = train_output["y_train"]
     y_test = train_output["y_test"]
     y_pred_train = train_output["model"].predict(train_output["dtrain"])
@@ -165,11 +211,12 @@ def _evaluation_metrics(train_output: dict) -> dict:
             y_pred_test,
             interval_config,
         ),
-        "workflow_backtest": {
-            "available": False,
-            "reason": "historical_market_lines_not_provided",
-            "reproducible_path": "odds.backtest.run_pick_backtest",
-        },
+        "workflow_backtest": _build_workflow_backtest_summary(
+            test_df=test_df,
+            y_test=y_test,
+            y_pred_test=y_pred_test,
+            historical_lines_df=historical_lines_df,
+        ),
         "sample_sizes": {
             "train_rows": int(len(train_output["X_train"])),
             "test_rows": int(len(train_output["X_test"])),
@@ -182,6 +229,7 @@ def build_training_metadata(
     train_df: pd.DataFrame,
     test_df: pd.DataFrame,
     train_output: dict,
+    historical_lines_df: pd.DataFrame | None = None,
 ) -> dict:
     uncertainty_model = fit_interval_calibration(
         train_output["X_train"],
@@ -205,8 +253,21 @@ def build_training_metadata(
             "train_game_date_range": _date_range(train_df),
             "test_game_date_range": _date_range(test_df),
         },
-        "evaluation_metrics": _evaluation_metrics(train_output),
+        "evaluation_metrics": _evaluation_metrics(
+            train_output,
+            test_df=test_df,
+            historical_lines_df=historical_lines_df,
+        ),
         "uncertainty_model": uncertainty_model,
+        "historical_lines_artifact": {
+            "selection_rule": "latest_pregame_snapshot_per_game_player_book_side",
+            "source_directory": str(RAW_HISTORICAL_LINES_DIR),
+            "rows": int(len(historical_lines_df)) if historical_lines_df is not None else 0,
+            "limitations": (
+                "v1 stores one selected line per game_date x player x sportsbook x side. "
+                "It does not persist full snapshot history or intraday replay data."
+            ),
+        },
     }
 
 
@@ -214,6 +275,7 @@ def save_artifacts_to_dir(
     output_dir: Path,
     pitcher_games: pd.DataFrame,
     model_df: pd.DataFrame,
+    historical_lines_df: pd.DataFrame,
     model,
     metadata: dict,
 ) -> dict[str, Path]:
@@ -222,6 +284,7 @@ def save_artifacts_to_dir(
 
     pitcher_games.to_csv(paths["pitcher_games"], index=False)
     model_df.to_csv(paths["model_df"], index=False)
+    historical_lines_df.to_csv(paths["historical_lines"], index=False)
     model.save_model(str(paths["model"]))
     paths["metadata"].write_text(json.dumps(metadata, indent=2), encoding="utf-8")
 
@@ -235,6 +298,7 @@ def validate_saved_artifacts(paths: dict[str, Path]) -> None:
 
     pitcher_games = pd.read_csv(paths["pitcher_games"])
     model_df = pd.read_csv(paths["model_df"])
+    historical_lines = pd.read_csv(paths["historical_lines"])
 
     if pitcher_games.empty:
         raise ValueError("Saved pitcher_games artifact is empty.")
@@ -242,18 +306,26 @@ def validate_saved_artifacts(paths: dict[str, Path]) -> None:
     if model_df.empty:
         raise ValueError("Saved model_df artifact is empty.")
 
+    if list(historical_lines.columns) != list(empty_historical_lines_df().columns):
+        raise ValueError("Saved historical_lines artifact does not match expected schema.")
+
 
 def build_training_artifacts() -> tuple[pd.DataFrame, pd.DataFrame, Path, Path]:
     ensure_artifact_dirs()
     reset_dir(STAGING_DIR)
 
     pitcher_games = build_historical_pitcher_games()
-    model, model_df, metadata = train_pitcher_k_model(pitcher_games)
+    historical_lines_df = build_native_historical_lines()
+    model, model_df, metadata = train_pitcher_k_model(
+        pitcher_games,
+        historical_lines_df=historical_lines_df,
+    )
 
     staging_paths = save_artifacts_to_dir(
         output_dir=STAGING_DIR,
         pitcher_games=pitcher_games,
         model_df=model_df,
+        historical_lines_df=historical_lines_df,
         model=model,
         metadata=metadata,
     )

--- a/MLB/src/jobs/build_training_artifacts.py
+++ b/MLB/src/jobs/build_training_artifacts.py
@@ -9,6 +9,13 @@ from pathlib import Path
 import pandas as pd
 
 from common.contracts import validate_pitcher_games_contract, require_columns
+from pitcher_k.evaluate import (
+    build_error_bucket_summary,
+    build_prediction_results,
+    evaluate_predictions,
+    fit_interval_calibration,
+    summarize_interval_coverage,
+)
 from pitcher_k.config import (
     BASE_FEATURES,
     RAW_STATCAST_START,
@@ -129,15 +136,44 @@ def _date_range(df: pd.DataFrame) -> dict[str, str | None]:
     }
 
 
-def _evaluation_metrics(train_output: dict) -> dict[str, float]:
+def _evaluation_metrics(train_output: dict) -> dict:
+    y_train = train_output["y_train"]
     y_test = train_output["y_test"]
-    y_pred = train_output["model"].predict(train_output["dtest"])
-    abs_errors = (y_pred - y_test).abs()
+    y_pred_train = train_output["model"].predict(train_output["dtrain"])
+    y_pred_test = train_output["model"].predict(train_output["dtest"])
+
+    test_results = build_prediction_results(
+        train_output["X_test"],
+        y_test,
+        y_pred_test,
+    )
+    interval_config = fit_interval_calibration(
+        train_output["X_train"],
+        y_train,
+        y_pred_train,
+    )
 
     return {
-        "mae": float(abs_errors.mean()),
-        "pred_min": float(y_pred.min()),
-        "pred_max": float(y_pred.max()),
+        "regression": evaluate_predictions(y_test, y_pred_test),
+        "bucketed_error": {
+            "bucket_by": "predicted_strikeouts",
+            "buckets": build_error_bucket_summary(test_results),
+        },
+        "uncertainty": summarize_interval_coverage(
+            train_output["X_test"],
+            y_test,
+            y_pred_test,
+            interval_config,
+        ),
+        "workflow_backtest": {
+            "available": False,
+            "reason": "historical_market_lines_not_provided",
+            "reproducible_path": "odds.backtest.run_pick_backtest",
+        },
+        "sample_sizes": {
+            "train_rows": int(len(train_output["X_train"])),
+            "test_rows": int(len(train_output["X_test"])),
+        },
     }
 
 
@@ -147,6 +183,11 @@ def build_training_metadata(
     test_df: pd.DataFrame,
     train_output: dict,
 ) -> dict:
+    uncertainty_model = fit_interval_calibration(
+        train_output["X_train"],
+        train_output["y_train"],
+        train_output["model"].predict(train_output["dtrain"]),
+    )
     return {
         "target": TARGET_COL,
         "features": BASE_FEATURES,
@@ -165,6 +206,7 @@ def build_training_metadata(
             "test_game_date_range": _date_range(test_df),
         },
         "evaluation_metrics": _evaluation_metrics(train_output),
+        "uncertainty_model": uncertainty_model,
     }
 
 

--- a/MLB/src/jobs/run_daily_card.py
+++ b/MLB/src/jobs/run_daily_card.py
@@ -22,6 +22,7 @@ from common.contracts import (
     require_columns,
 )
 from common.workflows import MLB_PITCHER_STRIKEOUT_WORKFLOW, ModelingWorkflowSpec
+from pitcher_k.evaluate import apply_interval_calibration
 
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
 DATA_DIR = PROJECT_ROOT / "data"
@@ -131,6 +132,23 @@ def build_today_predictions_for_workflow(
     return today_preds
 
 
+def apply_metadata_uncertainty(
+    today_preds: pd.DataFrame,
+    metadata: dict | None,
+) -> pd.DataFrame:
+    """
+    Re-apply interval bounds using the saved calibration config when available.
+    """
+    if today_preds.empty:
+        return today_preds
+
+    interval_config = (metadata or {}).get("uncertainty_model")
+    if not interval_config:
+        return today_preds
+
+    return apply_interval_calibration(today_preds, interval_config)
+
+
 def save_outputs(
     starters_df: pd.DataFrame,
     today_preds: pd.DataFrame,
@@ -177,7 +195,7 @@ def run_daily_card(
     validate_starters_contract(starters_df)
     pitcher_games = load_pitcher_games_artifact()
     model = load_model_artifact()
-    load_model_metadata()
+    metadata = load_model_metadata()
 
     today_preds = build_today_predictions_for_workflow(
         starters_df=starters_df,
@@ -185,6 +203,7 @@ def run_daily_card(
         model=model,
         workflow=workflow,
     )
+    today_preds = apply_metadata_uncertainty(today_preds, metadata)
 
     if today_preds.empty:
         raise ValueError("No today predictions were generated.")

--- a/MLB/src/odds/backtest.py
+++ b/MLB/src/odds/backtest.py
@@ -1,0 +1,192 @@
+from __future__ import annotations
+
+import math
+
+import numpy as np
+import pandas as pd
+
+from common.contracts import require_columns, validate_joined_odds_contract
+from odds.create_picks import build_daily_picks
+from odds.policy import DEFAULT_MLB_PITCHER_STRIKEOUT_POLICY, PickRankingPolicy
+
+BACKTEST_REQUIRED_COLUMNS = ["actual_strikeouts"]
+
+
+def _line_band(line: float) -> str:
+    if pd.isna(line):
+        return "unknown"
+    if line <= 4.5:
+        return "<=4.5"
+    if line <= 5.5:
+        return "4.5-5.5"
+    if line <= 6.5:
+        return "5.5-6.5"
+    if line <= 7.5:
+        return "6.5-7.5"
+    return "7.5+"
+
+
+def _grade_pick_outcome(actual: float, line: float, pick_side: str) -> str:
+    if pick_side == "over":
+        if actual > line:
+            return "win"
+        if actual < line:
+            return "loss"
+        return "push"
+
+    if actual < line:
+        return "win"
+    if actual > line:
+        return "loss"
+    return "push"
+
+
+def _american_odds_profit_units(price: float, outcome: str) -> float:
+    if outcome == "push":
+        return 0.0
+    if outcome == "loss":
+        return -1.0
+
+    price = float(price)
+    if price > 0:
+        return price / 100.0
+    return 100.0 / abs(price)
+
+
+def grade_pick_backtest(
+    picks_df: pd.DataFrame,
+    *,
+    actual_column: str = "actual_strikeouts",
+) -> pd.DataFrame:
+    require_columns(
+        picks_df,
+        [
+            "player_name",
+            "book",
+            "pick_side",
+            "line",
+            "price",
+            "pick_type",
+            "confidence_tier",
+            actual_column,
+        ],
+        "picks_backtest_df",
+    )
+
+    graded = picks_df.copy()
+    graded["outcome"] = graded.apply(
+        lambda row: _grade_pick_outcome(
+            actual=float(row[actual_column]),
+            line=float(row["line"]),
+            pick_side=str(row["pick_side"]).lower(),
+        ),
+        axis=1,
+    )
+    graded["is_win"] = graded["outcome"] == "win"
+    graded["is_loss"] = graded["outcome"] == "loss"
+    graded["is_push"] = graded["outcome"] == "push"
+    graded["decision"] = ~graded["is_push"]
+    graded["profit_units"] = graded.apply(
+        lambda row: _american_odds_profit_units(float(row["price"]), str(row["outcome"])),
+        axis=1,
+    )
+    graded["line_band"] = graded["line"].apply(_line_band)
+    return graded
+
+
+def _summarize_groups(graded_df: pd.DataFrame, group_column: str | None = None) -> list[dict]:
+    if graded_df.empty:
+        return []
+
+    working = graded_df.copy()
+    if group_column is None:
+        working = working.assign(_overall="overall")
+        group_cols = ["_overall"]
+    else:
+        group_cols = [group_column]
+
+    summary = (
+        working.groupby(group_cols, dropna=False)
+        .agg(
+            picks=("player_name", "size"),
+            wins=("is_win", "sum"),
+            losses=("is_loss", "sum"),
+            pushes=("is_push", "sum"),
+            decisions=("decision", "sum"),
+            avg_edge=("edge", "mean"),
+            avg_value_score=("value_score", "mean"),
+            profit_units=("profit_units", "sum"),
+        )
+        .reset_index()
+    )
+    summary["win_rate"] = np.where(
+        summary["decisions"] > 0,
+        summary["wins"] / summary["decisions"],
+        np.nan,
+    )
+    summary["roi_per_pick"] = np.where(
+        summary["picks"] > 0,
+        summary["profit_units"] / summary["picks"],
+        np.nan,
+    )
+
+    records = summary.to_dict(orient="records")
+    for record in records:
+        if "_overall" in record:
+            record.pop("_overall", None)
+        for key, value in list(record.items()):
+            if isinstance(value, float) and math.isnan(value):
+                record[key] = None
+    return records
+
+
+def run_pick_backtest(
+    joined_df: pd.DataFrame,
+    *,
+    policy: PickRankingPolicy = DEFAULT_MLB_PITCHER_STRIKEOUT_POLICY,
+    actual_column: str = "actual_strikeouts",
+) -> dict:
+    """
+    Backtest the same market-selection and pick-tier workflow used for live cards.
+    """
+    validate_joined_odds_contract(joined_df)
+    require_columns(joined_df, BACKTEST_REQUIRED_COLUMNS, "joined_odds_backtest_df")
+
+    scored_input = joined_df.dropna(subset=[actual_column]).copy()
+    if scored_input.empty:
+        return {
+            "available": False,
+            "reason": "no_rows_with_realized_outcomes",
+            "overall": [],
+            "by_pick_type": [],
+            "by_confidence_tier": [],
+            "by_book": [],
+            "by_line_band": [],
+            "by_pick_side": [],
+            "graded_picks": pd.DataFrame(),
+        }
+
+    picks = build_daily_picks(scored_input, policy=policy)
+    if picks.empty:
+        return {
+            "available": True,
+            "overall": [],
+            "by_pick_type": [],
+            "by_confidence_tier": [],
+            "by_book": [],
+            "by_line_band": [],
+            "by_pick_side": [],
+            "graded_picks": picks,
+        }
+
+    graded = grade_pick_backtest(picks, actual_column=actual_column)
+    return {
+        "available": True,
+        "overall": _summarize_groups(graded),
+        "by_pick_type": _summarize_groups(graded, "pick_type"),
+        "by_confidence_tier": _summarize_groups(graded, "confidence_tier"),
+        "by_book": _summarize_groups(graded, "book"),
+        "by_line_band": _summarize_groups(graded, "line_band"),
+        "by_pick_side": _summarize_groups(graded, "pick_side"),
+        "graded_picks": graded,
+    }

--- a/MLB/src/odds/backtest.py
+++ b/MLB/src/odds/backtest.py
@@ -6,6 +6,7 @@ import numpy as np
 import pandas as pd
 
 from common.contracts import require_columns, validate_joined_odds_contract
+from odds.compare import join_projections_to_historical_lines
 from odds.create_picks import build_daily_picks
 from odds.policy import DEFAULT_MLB_PITCHER_STRIKEOUT_POLICY, PickRankingPolicy
 
@@ -190,3 +191,58 @@ def run_pick_backtest(
         "by_pick_side": _summarize_groups(graded, "pick_side"),
         "graded_picks": graded,
     }
+
+
+def summarize_backtest_for_metadata(backtest_result: dict) -> dict:
+    """
+    Strip non-serializable dataframe payloads from a backtest result.
+    """
+    summary = {
+        key: value
+        for key, value in backtest_result.items()
+        if key != "graded_picks"
+    }
+    graded = backtest_result.get("graded_picks")
+    summary["graded_pick_rows"] = int(len(graded)) if isinstance(graded, pd.DataFrame) else 0
+    return summary
+
+
+def run_historical_workflow_backtest(
+    projections: pd.DataFrame,
+    historical_lines_df: pd.DataFrame,
+    *,
+    participant_key: str = "player_name",
+    projection_join_key: str = "player_name_norm",
+    lines_join_key: str = "player_name_norm",
+    actual_column: str = "actual_strikeouts",
+    policy: PickRankingPolicy = DEFAULT_MLB_PITCHER_STRIKEOUT_POLICY,
+) -> dict:
+    """
+    Join historical projections to curated native historical lines and run the
+    same workflow backtest used for live picks.
+    """
+    joined = join_projections_to_historical_lines(
+        projections,
+        historical_lines_df,
+        participant_key=participant_key,
+        projection_join_key=projection_join_key,
+        lines_join_key=lines_join_key,
+    )
+    if joined.empty:
+        return {
+            "available": False,
+            "reason": "no_matching_historical_lines_for_projections",
+            "overall": [],
+            "by_pick_type": [],
+            "by_confidence_tier": [],
+            "by_book": [],
+            "by_line_band": [],
+            "by_pick_side": [],
+            "graded_picks": pd.DataFrame(),
+        }
+
+    return run_pick_backtest(
+        joined,
+        actual_column=actual_column,
+        policy=policy,
+    )

--- a/MLB/src/odds/compare.py
+++ b/MLB/src/odds/compare.py
@@ -76,6 +76,57 @@ def join_projections_to_odds(
     return merged
 
 
+def join_projections_to_historical_lines(
+    projections: pd.DataFrame,
+    historical_lines_df: pd.DataFrame,
+    *,
+    participant_key: str = "player_name",
+    projection_join_key: str = "player_name_norm",
+    lines_join_key: str = "player_name_norm",
+    projection_date_key: str = "game_date",
+    lines_date_key: str = "game_date",
+) -> pd.DataFrame:
+    proj = prepare_projection_df(
+        projections,
+        participant_key=participant_key,
+        projection_join_key=projection_join_key,
+    )
+
+    if historical_lines_df.empty:
+        return pd.DataFrame()
+
+    require_columns(
+        historical_lines_df,
+        [lines_join_key, lines_date_key, "bookmaker", "side", "line", "price"],
+        "historical_lines_df",
+    )
+    require_columns(proj, [projection_date_key], "projections_df")
+
+    proj = proj.copy()
+    lines = historical_lines_df.copy()
+    proj[projection_date_key] = pd.to_datetime(proj[projection_date_key]).dt.strftime("%Y-%m-%d")
+    lines[lines_date_key] = pd.to_datetime(lines[lines_date_key]).dt.strftime("%Y-%m-%d")
+
+    merged = proj.merge(
+        lines,
+        left_on=[projection_join_key, projection_date_key],
+        right_on=[lines_join_key, lines_date_key],
+        how="inner",
+        suffixes=("_proj", "_line"),
+    )
+
+    if merged.empty:
+        return merged
+
+    require_columns(
+        merged,
+        ["predicted_strikeouts", "line"],
+        "joined_historical_lines_df",
+    )
+    merged["edge"] = merged["predicted_strikeouts"] - merged["line"]
+    return merged
+
+
 def best_over_edges(
     joined: pd.DataFrame,
     *,

--- a/MLB/src/odds/historical_lines.py
+++ b/MLB/src/odds/historical_lines.py
@@ -1,0 +1,212 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandas as pd
+
+from common.contracts import require_columns, validate_historical_lines_contract
+from odds.normalize import normalize_player_name
+from pitcher_k.config import PITCHER_K_PROP_MARKET
+
+RAW_HISTORICAL_LINES_REQUIRED_COLUMNS = [
+    "game_date",
+    "player_name",
+    "market_key",
+    "bookmaker",
+    "side",
+    "line",
+    "price",
+]
+
+HISTORICAL_LINES_COLUMNS = [
+    "game_date",
+    "player_name",
+    "player_name_norm",
+    "market_key",
+    "bookmaker",
+    "bookmaker_key",
+    "side",
+    "line",
+    "price",
+    "event_id",
+    "commence_time",
+    "selection_rule",
+    "source",
+    "pulled_at",
+    "snapshot_type",
+    "is_closing_line",
+    "snapshot_rank",
+]
+
+DEFAULT_SELECTION_RULE = "latest_pregame_snapshot_per_game_player_book_side"
+DEFAULT_SOURCE = "native_raw_historical_lines"
+
+
+def empty_historical_lines_df() -> pd.DataFrame:
+    return pd.DataFrame(columns=HISTORICAL_LINES_COLUMNS)
+
+
+def _optional_series(df: pd.DataFrame, column: str, default) -> pd.Series:
+    if column in df.columns:
+        return df[column]
+    return pd.Series([default] * len(df), index=df.index)
+
+
+def load_raw_historical_line_snapshots(raw_dir: Path) -> pd.DataFrame:
+    """
+    Load raw historical line snapshot CSVs from disk.
+    """
+    if not raw_dir.exists():
+        return pd.DataFrame()
+
+    csv_paths = sorted(raw_dir.rglob("*.csv"))
+    if not csv_paths:
+        return pd.DataFrame()
+
+    frames = [pd.read_csv(path) for path in csv_paths]
+    if not frames:
+        return pd.DataFrame()
+
+    loaded = pd.concat(frames, ignore_index=True)
+    return loaded
+
+
+def normalize_historical_line_snapshots(
+    raw_df: pd.DataFrame,
+    *,
+    market_key: str = PITCHER_K_PROP_MARKET,
+    selection_rule: str = DEFAULT_SELECTION_RULE,
+    default_source: str = DEFAULT_SOURCE,
+) -> pd.DataFrame:
+    """
+    Normalize raw historical line snapshots into a canonical schema.
+    """
+    if raw_df.empty:
+        return empty_historical_lines_df()
+
+    require_columns(raw_df, RAW_HISTORICAL_LINES_REQUIRED_COLUMNS, "raw_historical_lines_df")
+
+    df = raw_df.copy()
+    df["game_date"] = pd.to_datetime(df["game_date"]).dt.strftime("%Y-%m-%d")
+    df["market_key"] = df["market_key"].astype(str)
+    df = df[df["market_key"] == market_key].copy()
+    if df.empty:
+        return empty_historical_lines_df()
+
+    df["player_name"] = df["player_name"].astype(str).str.strip()
+    df["player_name_norm"] = df["player_name"].apply(normalize_player_name)
+    df["bookmaker"] = df["bookmaker"].astype(str).str.strip()
+    df["bookmaker_key"] = _optional_series(df, "bookmaker_key", "").astype(str).str.strip()
+    df.loc[df["bookmaker_key"] == "", "bookmaker_key"] = df["bookmaker"]
+    df["side"] = df["side"].astype(str).str.strip()
+    df["line"] = pd.to_numeric(df["line"], errors="coerce")
+    df["price"] = pd.to_numeric(df["price"], errors="coerce")
+    df["event_id"] = _optional_series(df, "event_id", None)
+    df["commence_time"] = pd.to_datetime(
+        _optional_series(df, "commence_time", None),
+        errors="coerce",
+        utc=True,
+    )
+    df["pulled_at"] = pd.to_datetime(
+        _optional_series(df, "pulled_at", None),
+        errors="coerce",
+        utc=True,
+    )
+    df["snapshot_type"] = _optional_series(df, "snapshot_type", "raw_snapshot").fillna("raw_snapshot")
+    df["source"] = _optional_series(df, "source", default_source).fillna(default_source)
+    df["selection_rule"] = _optional_series(df, "selection_rule", selection_rule).fillna(selection_rule)
+
+    df["is_closing_line"] = False
+    if "is_closing_line" in df.columns:
+        df["is_closing_line"] = df["is_closing_line"].fillna(False).astype(bool)
+
+    df["snapshot_rank"] = pd.to_numeric(
+        _optional_series(df, "snapshot_rank", None),
+        errors="coerce",
+    )
+
+    return df[HISTORICAL_LINES_COLUMNS]
+
+
+def curate_historical_lines(
+    snapshots_df: pd.DataFrame,
+    *,
+    selection_rule: str = DEFAULT_SELECTION_RULE,
+) -> pd.DataFrame:
+    """
+    Select one deterministic line per game_date x player x sportsbook x side.
+    Prefers the latest snapshot at or before commence_time; otherwise falls back
+    to the latest available snapshot.
+    """
+    if snapshots_df.empty:
+        return empty_historical_lines_df()
+
+    df = snapshots_df.copy()
+    require_columns(
+        df,
+        [
+            "game_date",
+            "player_name",
+            "player_name_norm",
+            "bookmaker",
+            "side",
+            "line",
+            "price",
+            "selection_rule",
+            "source",
+        ],
+        "historical_line_snapshots_df",
+    )
+
+    df["selection_rule"] = selection_rule
+    pregame_mask = (
+        df["pulled_at"].notna()
+        & df["commence_time"].notna()
+        & (df["pulled_at"] <= df["commence_time"])
+    )
+    df["snapshot_sort_ts"] = df["pulled_at"].fillna(df["commence_time"])
+    df["is_pregame_snapshot"] = pregame_mask
+    df["snapshot_rank"] = pd.to_numeric(df["snapshot_rank"], errors="coerce")
+
+    group_keys = ["game_date", "player_name_norm", "bookmaker", "side"]
+
+    def select_group(group: pd.DataFrame) -> pd.Series:
+        pregame = group[group["is_pregame_snapshot"]].copy()
+        candidates = pregame if not pregame.empty else group.copy()
+        candidates = candidates.sort_values(
+            by=["snapshot_sort_ts", "snapshot_rank", "line", "price"],
+            ascending=[False, False, False, False],
+            na_position="last",
+        )
+        selected = candidates.iloc[0].copy()
+        selected["is_closing_line"] = bool(not pregame.empty)
+        return selected
+
+    curated = (
+        df.groupby(group_keys, as_index=False, group_keys=False)
+        .apply(select_group)
+        .reset_index(drop=True)
+    )
+
+    curated = curated[HISTORICAL_LINES_COLUMNS].copy()
+    validate_historical_lines_contract(curated)
+    return curated
+
+
+def build_historical_lines_artifact_df(
+    raw_dir: Path,
+    *,
+    market_key: str = PITCHER_K_PROP_MARKET,
+    selection_rule: str = DEFAULT_SELECTION_RULE,
+) -> pd.DataFrame:
+    raw_df = load_raw_historical_line_snapshots(raw_dir)
+    snapshots_df = normalize_historical_line_snapshots(
+        raw_df,
+        market_key=market_key,
+        selection_rule=selection_rule,
+    )
+    curated = curate_historical_lines(
+        snapshots_df,
+        selection_rule=selection_rule,
+    )
+    return curated

--- a/MLB/src/pitcher_k/evaluate.py
+++ b/MLB/src/pitcher_k/evaluate.py
@@ -1,20 +1,33 @@
-# src/pitcher_k/evaluate.py
+import math
 
 import matplotlib.pyplot as plt
+import numpy as np
 import pandas as pd
-from sklearn.metrics import mean_absolute_error
+
+DEFAULT_INTERVAL_COVERAGE = 0.8
+DEFAULT_INTERVAL_STDDEV_COLUMN = "strikeouts_stddev_last10"
 
 
 def evaluate_predictions(y_true, y_pred) -> dict:
     """
-    Return core regression metrics.
+    Return richer regression metrics for model governance.
     """
-    mae = mean_absolute_error(y_true, y_pred)
+    y_true_series = pd.Series(y_true, dtype="float64")
+    y_pred_series = pd.Series(y_pred, dtype="float64")
+    errors = y_pred_series - y_true_series
+    abs_errors = errors.abs()
 
     return {
-        "mae": mae,
-        "pred_min": float(min(y_pred)),
-        "pred_max": float(max(y_pred)),
+        "mae": float(abs_errors.mean()),
+        "rmse": float(np.sqrt(np.mean(np.square(errors)))),
+        "median_absolute_error": float(abs_errors.median()),
+        "bias": float(errors.mean()),
+        "abs_error_p75": float(abs_errors.quantile(0.75)),
+        "abs_error_p90": float(abs_errors.quantile(0.90)),
+        "pred_min": float(y_pred_series.min()),
+        "pred_max": float(y_pred_series.max()),
+        "actual_min": float(y_true_series.min()),
+        "actual_max": float(y_true_series.max()),
     }
 
 
@@ -28,6 +41,180 @@ def build_prediction_results(X_test: pd.DataFrame, y_test, y_pred) -> pd.DataFra
     results["error"] = results["predicted_strikeouts"] - results["actual_strikeouts"]
     results["abs_error"] = results["error"].abs()
     return results
+
+
+def fit_interval_calibration(
+    X_calibration: pd.DataFrame,
+    y_true,
+    y_pred,
+    *,
+    stddev_column: str = DEFAULT_INTERVAL_STDDEV_COLUMN,
+    nominal_coverage: float = DEFAULT_INTERVAL_COVERAGE,
+) -> dict:
+    """
+    Fit a scalar interval multiplier so `prediction +/- multiplier * recent_stddev`
+    has an interpretable empirical coverage target.
+    """
+    calibration_df = pd.DataFrame(
+        {
+            "actual": pd.Series(y_true, dtype="float64").reset_index(drop=True),
+            "predicted": pd.Series(y_pred, dtype="float64").reset_index(drop=True),
+        }
+    )
+    if stddev_column in X_calibration.columns:
+        calibration_df["base_std_dev"] = (
+            pd.to_numeric(X_calibration[stddev_column], errors="coerce")
+            .fillna(0.0)
+            .clip(lower=0.0)
+            .reset_index(drop=True)
+        )
+    else:
+        calibration_df["base_std_dev"] = 0.0
+
+    calibration_df["abs_error"] = (calibration_df["predicted"] - calibration_df["actual"]).abs()
+    usable = calibration_df[calibration_df["base_std_dev"] > 0].copy()
+
+    if usable.empty:
+        interval_multiplier = 1.0
+        calibration_rows = 0
+    else:
+        usable["scaled_abs_error"] = usable["abs_error"] / usable["base_std_dev"]
+        interval_multiplier = float(
+            usable["scaled_abs_error"].quantile(nominal_coverage, interpolation="linear")
+        )
+        if not math.isfinite(interval_multiplier) or interval_multiplier <= 0:
+            interval_multiplier = 1.0
+        calibration_rows = int(len(usable))
+
+    return {
+        "method": "recent_stddev_scaled_by_empirical_residual_quantile",
+        "base_stddev_column": stddev_column,
+        "nominal_coverage": float(nominal_coverage),
+        "interval_multiplier": float(interval_multiplier),
+        "calibration_rows": calibration_rows,
+        "documented_interpretation": (
+            "lower_bound and upper_bound represent an empirical central prediction "
+            f"interval targeting {nominal_coverage:.0%} coverage on held-out data when "
+            "the recent strikeout standard deviation signal is present."
+        ),
+    }
+
+
+def apply_interval_calibration(
+    pred_df: pd.DataFrame,
+    interval_config: dict | None = None,
+    *,
+    stddev_column: str = DEFAULT_INTERVAL_STDDEV_COLUMN,
+) -> pd.DataFrame:
+    """
+    Apply calibrated interval widths to a prediction dataframe.
+    """
+    interval_config = interval_config or {}
+    multiplier = float(interval_config.get("interval_multiplier", 1.0))
+
+    calibrated = pred_df.copy()
+    if "std_dev" in calibrated.columns:
+        base_std_dev = pd.to_numeric(calibrated["std_dev"], errors="coerce").fillna(0.0)
+    elif stddev_column in calibrated.columns:
+        base_std_dev = pd.to_numeric(calibrated[stddev_column], errors="coerce").fillna(0.0)
+    else:
+        base_std_dev = pd.Series(0.0, index=calibrated.index, dtype="float64")
+
+    calibrated["raw_std_dev"] = base_std_dev.clip(lower=0.0)
+    calibrated["std_dev"] = calibrated["raw_std_dev"] * multiplier
+    calibrated["lower_bound"] = (calibrated["predicted_strikeouts"] - calibrated["std_dev"]).clip(lower=0.0)
+    calibrated["upper_bound"] = calibrated["predicted_strikeouts"] + calibrated["std_dev"]
+
+    if interval_config:
+        calibrated["interval_coverage_target"] = float(
+            interval_config.get("nominal_coverage", DEFAULT_INTERVAL_COVERAGE)
+        )
+        calibrated["interval_multiplier"] = multiplier
+
+    return calibrated
+
+
+def summarize_interval_coverage(
+    X_eval: pd.DataFrame,
+    y_true,
+    y_pred,
+    interval_config: dict | None = None,
+    *,
+    stddev_column: str = DEFAULT_INTERVAL_STDDEV_COLUMN,
+) -> dict:
+    """
+    Measure empirical coverage and interval width on evaluation data.
+    """
+    coverage_df = X_eval.copy().reset_index(drop=True)
+    coverage_df["predicted_strikeouts"] = pd.Series(y_pred, dtype="float64").reset_index(drop=True)
+    coverage_df["actual_strikeouts"] = pd.Series(y_true, dtype="float64").reset_index(drop=True)
+    coverage_df = apply_interval_calibration(
+        coverage_df,
+        interval_config,
+        stddev_column=stddev_column,
+    )
+
+    within_bounds = coverage_df["actual_strikeouts"].between(
+        coverage_df["lower_bound"],
+        coverage_df["upper_bound"],
+        inclusive="both",
+    )
+
+    return {
+        "interval_method": (interval_config or {}).get(
+            "method",
+            "recent_stddev_without_calibration",
+        ),
+        "nominal_coverage": float(
+            (interval_config or {}).get("nominal_coverage", DEFAULT_INTERVAL_COVERAGE)
+        ),
+        "empirical_coverage": float(within_bounds.mean()),
+        "mean_interval_width": float((coverage_df["upper_bound"] - coverage_df["lower_bound"]).mean()),
+        "mean_half_width": float(coverage_df["std_dev"].mean()),
+        "miss_rate_below_lower_bound": float(
+            (coverage_df["actual_strikeouts"] < coverage_df["lower_bound"]).mean()
+        ),
+        "miss_rate_above_upper_bound": float(
+            (coverage_df["actual_strikeouts"] > coverage_df["upper_bound"]).mean()
+        ),
+        "rows": int(len(coverage_df)),
+    }
+
+
+def build_error_bucket_summary(
+    results_df: pd.DataFrame,
+    *,
+    bucket_column: str = "predicted_strikeouts",
+) -> list[dict]:
+    """
+    Summarize forecast quality across practical strikeout bands.
+    """
+    working = results_df.copy()
+    bins = [-np.inf, 4.5, 5.5, 6.5, 7.5, np.inf]
+    labels = ["<=4.5", "4.5-5.5", "5.5-6.5", "6.5-7.5", "7.5+"]
+    working["error_bucket"] = pd.cut(
+        working[bucket_column],
+        bins=bins,
+        labels=labels,
+        include_lowest=True,
+        right=True,
+    )
+
+    summary = (
+        working.groupby("error_bucket", observed=False)
+        .agg(
+            rows=(bucket_column, "size"),
+            mean_actual=("actual_strikeouts", "mean"),
+            mean_prediction=("predicted_strikeouts", "mean"),
+            mae=("abs_error", "mean"),
+            bias=("error", "mean"),
+        )
+        .reset_index()
+    )
+    summary = summary[summary["rows"] > 0]
+    summary["error_bucket"] = summary["error_bucket"].astype(str)
+
+    return summary.to_dict(orient="records")
 
 
 def plot_actual_vs_predicted(y_true, y_pred):

--- a/MLB/src/pitcher_k/predict.py
+++ b/MLB/src/pitcher_k/predict.py
@@ -4,11 +4,15 @@ import pandas as pd
 import xgboost as xgb
 
 from .config import BASE_FEATURES
+from .evaluate import apply_interval_calibration
 
 
-def _add_projection_uncertainty(pred_df: pd.DataFrame) -> pd.DataFrame:
+def _add_projection_uncertainty(
+    pred_df: pd.DataFrame,
+    interval_config: dict | None = None,
+) -> pd.DataFrame:
     """
-    Add simple uncertainty estimates derived from recent historical strikeout variance.
+    Add uncertainty estimates derived from recent historical strikeout variance.
     """
     pred_df = pred_df.copy()
 
@@ -17,20 +21,22 @@ def _add_projection_uncertainty(pred_df: pd.DataFrame) -> pd.DataFrame:
     else:
         pred_df["std_dev"] = pred_df["strikeouts_stddev_last10"].fillna(0.0).clip(lower=0.0)
 
-    pred_df["lower_bound"] = (pred_df["predicted_strikeouts"] - pred_df["std_dev"]).clip(lower=0.0)
-    pred_df["upper_bound"] = pred_df["predicted_strikeouts"] + pred_df["std_dev"]
-
-    return pred_df
+    return apply_interval_calibration(pred_df, interval_config)
 
 
-def predict_on_dataframe(model, df: pd.DataFrame, features: list[str] = BASE_FEATURES) -> pd.DataFrame:
+def predict_on_dataframe(
+    model,
+    df: pd.DataFrame,
+    features: list[str] = BASE_FEATURES,
+    interval_config: dict | None = None,
+) -> pd.DataFrame:
     """
     Generate predictions for any dataframe containing the model features.
     """
     pred_df = df.copy()
     dmatrix = xgb.DMatrix(pred_df[features], feature_names=features)
     pred_df["predicted_strikeouts"] = model.predict(dmatrix)
-    return _add_projection_uncertainty(pred_df)
+    return _add_projection_uncertainty(pred_df, interval_config)
 
 
 def get_latest_pitcher_rows(model_df: pd.DataFrame) -> pd.DataFrame:

--- a/MLB/tests/jobs/test_build_historical_lines_artifact.py
+++ b/MLB/tests/jobs/test_build_historical_lines_artifact.py
@@ -1,0 +1,45 @@
+import pandas as pd
+
+from jobs import build_historical_lines_artifact as historical_lines_job
+from jobs import build_training_artifacts as training_job
+
+
+def test_build_historical_lines_artifact_writes_native_curated_file(tmp_path, monkeypatch):
+    raw_dir = tmp_path / "data" / "raw" / "historical_lines"
+    latest_dir = tmp_path / "data" / "artifacts" / "latest"
+    previous_dir = tmp_path / "data" / "artifacts" / "previous"
+    raw_dir.mkdir(parents=True, exist_ok=True)
+
+    pd.DataFrame(
+        [
+            {
+                "game_date": "2025-08-02",
+                "player_name": "Jacob deGrom",
+                "market_key": "pitcher_strikeouts",
+                "bookmaker": "DraftKings",
+                "bookmaker_key": "draftkings",
+                "side": "Over",
+                "line": 6.5,
+                "price": -120,
+                "event_id": "evt_1",
+                "commence_time": "2025-08-02T23:10:00Z",
+                "pulled_at": "2025-08-02T22:00:00Z",
+                "snapshot_type": "raw",
+                "source": "fixture",
+            }
+        ]
+    ).to_csv(raw_dir / "sample.csv", index=False)
+
+    monkeypatch.setattr(historical_lines_job, "RAW_HISTORICAL_LINES_DIR", raw_dir)
+    monkeypatch.setattr(historical_lines_job, "LATEST_DIR", latest_dir)
+    monkeypatch.setattr(historical_lines_job, "PREVIOUS_DIR", previous_dir)
+    monkeypatch.setattr(training_job, "LATEST_DIR", latest_dir)
+    monkeypatch.setattr(training_job, "PREVIOUS_DIR", previous_dir)
+
+    output_path, rows = historical_lines_job.build_historical_lines_artifact()
+    saved = pd.read_csv(output_path)
+
+    assert output_path.exists()
+    assert rows == 1
+    assert saved.loc[0, "player_name_norm"] == "jacob degrom"
+    assert saved.loc[0, "selection_rule"] == "latest_pregame_snapshot_per_game_player_book_side"

--- a/MLB/tests/jobs/test_build_training_artifacts.py
+++ b/MLB/tests/jobs/test_build_training_artifacts.py
@@ -3,6 +3,7 @@ import json
 import pandas as pd
 
 from jobs import build_training_artifacts as training_job
+from odds.historical_lines import empty_historical_lines_df
 
 
 class FakeModel:
@@ -20,10 +21,20 @@ class FakePredictModel:
         raise AssertionError(f"Unexpected dmatrix: {dmatrix}")
 
 
+class FakeSingleTestPredictModel:
+    def predict(self, dmatrix):
+        if dmatrix == "train":
+            return pd.Series([4.8, 6.2], dtype="float64")
+        if dmatrix == "test":
+            return pd.Series([7.3], dtype="float64")
+        raise AssertionError(f"Unexpected dmatrix: {dmatrix}")
+
+
 def test_save_artifacts_to_dir_writes_metadata_json(tmp_path):
     output_dir = tmp_path / "artifacts"
     pitcher_games = pd.DataFrame([{"game_date": "2026-04-19", "pitcher": 1}])
     model_df = pd.DataFrame([{"game_date": "2026-04-19", "strikeouts": 7}])
+    historical_lines_df = empty_historical_lines_df()
     metadata = {
         "target": "strikeouts",
         "features": ["pitches_last3"],
@@ -36,6 +47,7 @@ def test_save_artifacts_to_dir_writes_metadata_json(tmp_path):
         output_dir=output_dir,
         pitcher_games=pitcher_games,
         model_df=model_df,
+        historical_lines_df=historical_lines_df,
         model=FakeModel(),
         metadata=metadata,
     )
@@ -56,6 +68,10 @@ def test_promote_latest_to_previous_preserves_matching_metadata(tmp_path, monkey
     latest_paths["model"].write_text("model-bytes", encoding="utf-8")
     latest_paths["pitcher_games"].write_text("game_date\n2026-04-19\n", encoding="utf-8")
     latest_paths["model_df"].write_text("game_date,strikeouts\n2026-04-19,7\n", encoding="utf-8")
+    latest_paths["historical_lines"].write_text(
+        ",".join(empty_historical_lines_df().columns) + "\n",
+        encoding="utf-8",
+    )
     latest_paths["metadata"].write_text(
         '{"target": "strikeouts", "training_window": {"train_split_date": "2025-08-01"}}',
         encoding="utf-8",
@@ -119,3 +135,76 @@ def test_build_training_metadata_includes_richer_evaluation_sections():
     assert evaluation["workflow_backtest"]["available"] is False
     assert metadata["uncertainty_model"]["interval_multiplier"] > 0
     assert "documented_interpretation" in metadata["uncertainty_model"]
+
+
+def test_build_training_metadata_uses_native_historical_lines_for_real_backtest():
+    model_df = pd.DataFrame(
+        [
+            {"game_date": "2025-07-30", "strikeouts": 5},
+            {"game_date": "2025-08-02", "strikeouts": 7},
+        ]
+    )
+    train_df = pd.DataFrame([{"game_date": "2025-07-30", "strikeouts": 5}])
+    test_df = pd.DataFrame(
+        [
+            {
+                "game_date": "2025-08-02",
+                "player_name": "Jacob deGrom",
+                "strikeouts": 7,
+            }
+        ]
+    )
+    train_output = {
+        "model": FakeSingleTestPredictModel(),
+        "dtrain": "train",
+        "dtest": "test",
+        "X_train": pd.DataFrame(
+            [
+                {"pitches_last3": 90.0, "strikeouts_stddev_last10": 1.1},
+                {"pitches_last3": 95.0, "strikeouts_stddev_last10": 1.4},
+            ]
+        ),
+        "X_test": pd.DataFrame(
+            [
+                {"pitches_last3": 92.0, "strikeouts_stddev_last10": 1.2},
+            ]
+        ),
+        "y_train": pd.Series([5.0, 6.0], dtype="float64"),
+        "y_test": pd.Series([7.0], dtype="float64"),
+    }
+    historical_lines_df = pd.DataFrame(
+        [
+            {
+                "game_date": "2025-08-02",
+                "player_name": "Jacob deGrom",
+                "player_name_norm": "jacob degrom",
+                "market_key": "pitcher_strikeouts",
+                "bookmaker": "DraftKings",
+                "bookmaker_key": "draftkings",
+                "side": "Over",
+                "line": 6.5,
+                "price": -120,
+                "event_id": "evt_1",
+                "commence_time": "2025-08-02T23:10:00Z",
+                "selection_rule": "latest_pregame_snapshot_per_game_player_book_side",
+                "source": "fixture",
+                "pulled_at": "2025-08-02T22:50:00Z",
+                "snapshot_type": "selected",
+                "is_closing_line": True,
+                "snapshot_rank": 1,
+            }
+        ]
+    )
+
+    metadata = training_job.build_training_metadata(
+        model_df=model_df,
+        train_df=train_df,
+        test_df=test_df,
+        train_output=train_output,
+        historical_lines_df=historical_lines_df,
+    )
+
+    workflow_backtest = metadata["evaluation_metrics"]["workflow_backtest"]
+    assert workflow_backtest["available"] is True
+    assert workflow_backtest["overall"][0]["picks"] == 1
+    assert workflow_backtest["by_book"][0]["book"] == "DraftKings"

--- a/MLB/tests/jobs/test_build_training_artifacts.py
+++ b/MLB/tests/jobs/test_build_training_artifacts.py
@@ -11,6 +11,15 @@ class FakeModel:
             handle.write("fake-model")
 
 
+class FakePredictModel:
+    def predict(self, dmatrix):
+        if dmatrix == "train":
+            return pd.Series([4.8, 6.2], dtype="float64")
+        if dmatrix == "test":
+            return pd.Series([5.4, 7.1], dtype="float64")
+        raise AssertionError(f"Unexpected dmatrix: {dmatrix}")
+
+
 def test_save_artifacts_to_dir_writes_metadata_json(tmp_path):
     output_dir = tmp_path / "artifacts"
     pitcher_games = pd.DataFrame([{"game_date": "2026-04-19", "pitcher": 1}])
@@ -63,3 +72,50 @@ def test_promote_latest_to_previous_preserves_matching_metadata(tmp_path, monkey
     assert previous_paths["model"].read_text(encoding="utf-8") == "model-bytes"
     assert saved_metadata["target"] == "strikeouts"
     assert saved_metadata["training_window"]["train_split_date"] == "2025-08-01"
+
+
+def test_build_training_metadata_includes_richer_evaluation_sections():
+    model_df = pd.DataFrame(
+        [
+            {"game_date": "2025-07-30", "strikeouts": 5},
+            {"game_date": "2025-08-02", "strikeouts": 7},
+        ]
+    )
+    train_df = pd.DataFrame([{"game_date": "2025-07-30", "strikeouts": 5}])
+    test_df = pd.DataFrame([{"game_date": "2025-08-02", "strikeouts": 7}])
+    train_output = {
+        "model": FakePredictModel(),
+        "dtrain": "train",
+        "dtest": "test",
+        "X_train": pd.DataFrame(
+            [
+                {"pitches_last3": 90.0, "strikeouts_stddev_last10": 1.1},
+                {"pitches_last3": 95.0, "strikeouts_stddev_last10": 1.4},
+            ]
+        ),
+        "X_test": pd.DataFrame(
+            [
+                {"pitches_last3": 92.0, "strikeouts_stddev_last10": 1.2},
+                {"pitches_last3": 98.0, "strikeouts_stddev_last10": 1.5},
+            ]
+        ),
+        "y_train": pd.Series([5.0, 6.0], dtype="float64"),
+        "y_test": pd.Series([5.0, 8.0], dtype="float64"),
+    }
+
+    metadata = training_job.build_training_metadata(
+        model_df=model_df,
+        train_df=train_df,
+        test_df=test_df,
+        train_output=train_output,
+    )
+
+    evaluation = metadata["evaluation_metrics"]
+
+    assert "regression" in evaluation
+    assert "bucketed_error" in evaluation
+    assert "uncertainty" in evaluation
+    assert "workflow_backtest" in evaluation
+    assert evaluation["workflow_backtest"]["available"] is False
+    assert metadata["uncertainty_model"]["interval_multiplier"] > 0
+    assert "documented_interpretation" in metadata["uncertainty_model"]

--- a/MLB/tests/jobs/test_run_daily_card.py
+++ b/MLB/tests/jobs/test_run_daily_card.py
@@ -540,3 +540,30 @@ def test_load_model_metadata_reads_matching_file_from_selected_artifact_dir(tmp_
     assert metadata["evaluation_metrics"]["mae"] == 0.9
     assert str(latest_dir / "metadata.json") in captured.out
     assert '"target": "strikeouts"' in captured.out
+
+
+def test_apply_metadata_uncertainty_uses_saved_interval_calibration():
+    today_preds = pd.DataFrame(
+        [
+            {
+                "player_name": "Jacob deGrom",
+                "predicted_strikeouts": 6.8,
+                "std_dev": 1.0,
+                "lower_bound": 5.8,
+                "upper_bound": 7.8,
+            }
+        ]
+    )
+    metadata = {
+        "uncertainty_model": {
+            "interval_multiplier": 1.4,
+            "nominal_coverage": 0.8,
+        }
+    }
+
+    adjusted = daily_card.apply_metadata_uncertainty(today_preds, metadata)
+
+    assert adjusted.loc[0, "raw_std_dev"] == pytest.approx(1.0)
+    assert adjusted.loc[0, "std_dev"] == pytest.approx(1.4)
+    assert adjusted.loc[0, "lower_bound"] == pytest.approx(5.4)
+    assert adjusted.loc[0, "upper_bound"] == pytest.approx(8.2)

--- a/MLB/tests/odds/test_backtest.py
+++ b/MLB/tests/odds/test_backtest.py
@@ -1,6 +1,6 @@
 import pandas as pd
 
-from odds.backtest import run_pick_backtest
+from odds.backtest import run_historical_workflow_backtest, run_pick_backtest
 
 
 def test_run_pick_backtest_summarizes_workflow_by_betting_segments():
@@ -72,3 +72,70 @@ def test_run_pick_backtest_summarizes_workflow_by_betting_segments():
 
     graded = backtest["graded_picks"]
     assert set(graded["outcome"]) == {"win", "loss"}
+
+
+def test_run_historical_workflow_backtest_uses_native_lines_artifact_rows():
+    projections = pd.DataFrame(
+        [
+            {
+                "game_date": "2025-08-02",
+                "player_name": "Official Over",
+                "predicted_strikeouts": 7.2,
+                "actual_strikeouts": 8,
+            },
+            {
+                "game_date": "2025-08-02",
+                "player_name": "Lean Under",
+                "predicted_strikeouts": 5.0,
+                "actual_strikeouts": 4,
+            },
+        ]
+    )
+    historical_lines = pd.DataFrame(
+        [
+            {
+                "game_date": "2025-08-02",
+                "player_name": "Official Over",
+                "player_name_norm": "official over",
+                "market_key": "pitcher_strikeouts",
+                "bookmaker": "DraftKings",
+                "bookmaker_key": "draftkings",
+                "side": "Over",
+                "line": 6.0,
+                "price": -110,
+                "event_id": "evt_1",
+                "commence_time": "2025-08-02T23:10:00Z",
+                "selection_rule": "latest_pregame_snapshot_per_game_player_book_side",
+                "source": "fixture",
+                "pulled_at": "2025-08-02T22:50:00Z",
+                "snapshot_type": "selected",
+                "is_closing_line": True,
+                "snapshot_rank": 1,
+            },
+            {
+                "game_date": "2025-08-02",
+                "player_name": "Lean Under",
+                "player_name_norm": "lean under",
+                "market_key": "pitcher_strikeouts",
+                "bookmaker": "Caesars",
+                "bookmaker_key": "caesars",
+                "side": "Under",
+                "line": 5.5,
+                "price": -115,
+                "event_id": "evt_1",
+                "commence_time": "2025-08-02T23:10:00Z",
+                "selection_rule": "latest_pregame_snapshot_per_game_player_book_side",
+                "source": "fixture",
+                "pulled_at": "2025-08-02T22:55:00Z",
+                "snapshot_type": "selected",
+                "is_closing_line": True,
+                "snapshot_rank": 1,
+            },
+        ]
+    )
+
+    backtest = run_historical_workflow_backtest(projections, historical_lines)
+
+    assert backtest["available"] is True
+    assert backtest["overall"][0]["picks"] == 2
+    assert backtest["overall"][0]["wins"] == 2

--- a/MLB/tests/odds/test_backtest.py
+++ b/MLB/tests/odds/test_backtest.py
@@ -1,0 +1,74 @@
+import pandas as pd
+
+from odds.backtest import run_pick_backtest
+
+
+def test_run_pick_backtest_summarizes_workflow_by_betting_segments():
+    joined_df = pd.DataFrame(
+        [
+            {
+                "player_name_proj": "Official Over",
+                "predicted_strikeouts": 7.2,
+                "bookmaker": "DraftKings",
+                "side": "Over",
+                "line": 6.0,
+                "price": -110,
+                "actual_strikeouts": 8,
+            },
+            {
+                "player_name_proj": "Official Over",
+                "predicted_strikeouts": 7.2,
+                "bookmaker": "FanDuel",
+                "side": "Over",
+                "line": 6.5,
+                "price": 105,
+                "actual_strikeouts": 8,
+            },
+            {
+                "player_name_proj": "Lean Under",
+                "predicted_strikeouts": 5.0,
+                "bookmaker": "Caesars",
+                "side": "Under",
+                "line": 5.5,
+                "price": -115,
+                "actual_strikeouts": 4,
+            },
+            {
+                "player_name_proj": "Pass Case",
+                "predicted_strikeouts": 4.7,
+                "bookmaker": "BetMGM",
+                "side": "Over",
+                "line": 4.5,
+                "price": -110,
+                "actual_strikeouts": 3,
+            },
+        ]
+    )
+
+    backtest = run_pick_backtest(joined_df)
+
+    assert backtest["available"] is True
+    assert len(backtest["overall"]) == 1
+    assert backtest["overall"][0]["picks"] == 3
+    assert backtest["overall"][0]["wins"] == 2
+    assert backtest["overall"][0]["losses"] == 1
+
+    by_pick_type = {row["pick_type"]: row for row in backtest["by_pick_type"]}
+    assert by_pick_type["official"]["wins"] == 1
+    assert by_pick_type["lean"]["wins"] == 1
+    assert by_pick_type["pass"]["losses"] == 1
+
+    by_book = {row["book"]: row for row in backtest["by_book"]}
+    assert set(by_book) == {"DraftKings", "Caesars", "BetMGM"}
+
+    by_side = {row["pick_side"]: row for row in backtest["by_pick_side"]}
+    assert by_side["over"]["picks"] == 2
+    assert by_side["under"]["picks"] == 1
+
+    by_band = {row["line_band"]: row for row in backtest["by_line_band"]}
+    assert by_band["5.5-6.5"]["picks"] == 1
+    assert by_band["4.5-5.5"]["picks"] == 1
+    assert by_band["<=4.5"]["picks"] == 1
+
+    graded = backtest["graded_picks"]
+    assert set(graded["outcome"]) == {"win", "loss"}

--- a/MLB/tests/odds/test_compare.py
+++ b/MLB/tests/odds/test_compare.py
@@ -6,6 +6,7 @@ import pytest
 from odds.compare import (
     prepare_projection_df,
     join_projections_to_odds,
+    join_projections_to_historical_lines,
     best_over_edges,
 )
 
@@ -312,3 +313,46 @@ def test_prepare_projection_df_raises_when_required_columns_missing():
 
     with pytest.raises(ValueError, match="projections_df is missing required columns"):
         prepare_projection_df(projections)
+
+
+def test_join_projections_to_historical_lines_matches_on_name_and_game_date():
+    projections = pd.DataFrame(
+        [
+            {
+                "game_date": "2025-08-02",
+                "player_name": "Jacob deGrom",
+                "predicted_strikeouts": 6.8,
+                "actual_strikeouts": 7,
+            }
+        ]
+    )
+    historical_lines = pd.DataFrame(
+        [
+            {
+                "game_date": "2025-08-02",
+                "player_name": "Jacob Degrom",
+                "player_name_norm": "jacob degrom",
+                "market_key": "pitcher_strikeouts",
+                "bookmaker": "DraftKings",
+                "bookmaker_key": "draftkings",
+                "side": "Over",
+                "line": 6.5,
+                "price": -120,
+                "event_id": "evt_1",
+                "commence_time": "2025-08-02T23:10:00Z",
+                "selection_rule": "latest_pregame_snapshot_per_game_player_book_side",
+                "source": "fixture",
+                "pulled_at": "2025-08-02T22:50:00Z",
+                "snapshot_type": "selected",
+                "is_closing_line": True,
+                "snapshot_rank": 1,
+            }
+        ]
+    )
+
+    joined = join_projections_to_historical_lines(projections, historical_lines)
+
+    assert len(joined) == 1
+    assert joined.loc[0, "player_name_proj"] == "Jacob deGrom"
+    assert joined.loc[0, "bookmaker"] == "DraftKings"
+    assert joined.loc[0, "edge"] == pytest.approx(0.3)

--- a/MLB/tests/odds/test_historical_lines.py
+++ b/MLB/tests/odds/test_historical_lines.py
@@ -1,0 +1,100 @@
+import pandas as pd
+import pytest
+
+from odds.historical_lines import (
+    DEFAULT_SELECTION_RULE,
+    build_historical_lines_artifact_df,
+    curate_historical_lines,
+    normalize_historical_line_snapshots,
+)
+
+
+def test_curate_historical_lines_prefers_latest_pregame_snapshot():
+    raw_df = pd.DataFrame(
+        [
+            {
+                "game_date": "2025-08-02",
+                "player_name": "Jacob deGrom",
+                "market_key": "pitcher_strikeouts",
+                "bookmaker": "DraftKings",
+                "bookmaker_key": "draftkings",
+                "side": "Over",
+                "line": 6.5,
+                "price": -120,
+                "event_id": "evt_1",
+                "commence_time": "2025-08-02T23:10:00Z",
+                "pulled_at": "2025-08-02T22:00:00Z",
+                "snapshot_type": "raw",
+                "source": "fixture",
+            },
+            {
+                "game_date": "2025-08-02",
+                "player_name": "Jacob deGrom",
+                "market_key": "pitcher_strikeouts",
+                "bookmaker": "DraftKings",
+                "bookmaker_key": "draftkings",
+                "side": "Over",
+                "line": 7.5,
+                "price": 100,
+                "event_id": "evt_1",
+                "commence_time": "2025-08-02T23:10:00Z",
+                "pulled_at": "2025-08-02T23:30:00Z",
+                "snapshot_type": "raw",
+                "source": "fixture",
+            },
+        ]
+    )
+
+    snapshots = normalize_historical_line_snapshots(raw_df)
+    curated = curate_historical_lines(snapshots)
+
+    assert len(curated) == 1
+    assert curated.loc[0, "line"] == pytest.approx(6.5)
+    assert curated.loc[0, "selection_rule"] == DEFAULT_SELECTION_RULE
+    assert bool(curated.loc[0, "is_closing_line"]) is True
+
+
+def test_build_historical_lines_artifact_df_is_deterministic_with_duplicate_snapshots(tmp_path):
+    raw_dir = tmp_path / "raw" / "historical_lines"
+    raw_dir.mkdir(parents=True, exist_ok=True)
+    raw_df = pd.DataFrame(
+        [
+            {
+                "game_date": "2025-08-02",
+                "player_name": "Jacob deGrom",
+                "market_key": "pitcher_strikeouts",
+                "bookmaker": "DraftKings",
+                "bookmaker_key": "draftkings",
+                "side": "Over",
+                "line": 6.5,
+                "price": -120,
+                "event_id": "evt_1",
+                "commence_time": "2025-08-02T23:10:00Z",
+                "pulled_at": "2025-08-02T22:00:00Z",
+                "snapshot_type": "raw",
+                "source": "fixture",
+            },
+            {
+                "game_date": "2025-08-02",
+                "player_name": "Jacob Degrom",
+                "market_key": "pitcher_strikeouts",
+                "bookmaker": "DraftKings",
+                "bookmaker_key": "draftkings",
+                "side": "Over",
+                "line": 7.0,
+                "price": -110,
+                "event_id": "evt_1",
+                "commence_time": "2025-08-02T23:10:00Z",
+                "pulled_at": "2025-08-02T22:30:00Z",
+                "snapshot_type": "raw",
+                "source": "fixture",
+            },
+        ]
+    )
+    raw_df.to_csv(raw_dir / "pitcher_strikeouts_sample.csv", index=False)
+
+    curated = build_historical_lines_artifact_df(raw_dir)
+
+    assert len(curated) == 1
+    assert curated.loc[0, "player_name_norm"] == "jacob degrom"
+    assert curated.loc[0, "line"] == pytest.approx(7.0)

--- a/MLB/tests/pitcher_k/test_predict.py
+++ b/MLB/tests/pitcher_k/test_predict.py
@@ -49,3 +49,27 @@ def test_predict_on_dataframe_falls_back_to_zero_uncertainty_when_history_missin
     assert result.loc[0, "std_dev"] == pytest.approx(0.0)
     assert result.loc[0, "lower_bound"] == pytest.approx(4.2)
     assert result.loc[0, "upper_bound"] == pytest.approx(4.2)
+
+
+def test_predict_on_dataframe_applies_interval_multiplier_when_provided():
+    df = pd.DataFrame(
+        [
+            {
+                "player_name": "Jacob deGrom",
+                "strikeouts_stddev_last10": 1.25,
+                **{feature: 1.0 for feature in BASE_FEATURES},
+            }
+        ]
+    )
+
+    result = predict_on_dataframe(
+        FakeModel([6.8]),
+        df,
+        interval_config={"interval_multiplier": 1.6, "nominal_coverage": 0.8},
+    )
+
+    assert result.loc[0, "raw_std_dev"] == pytest.approx(1.25)
+    assert result.loc[0, "std_dev"] == pytest.approx(2.0)
+    assert result.loc[0, "lower_bound"] == pytest.approx(4.8)
+    assert result.loc[0, "upper_bound"] == pytest.approx(8.8)
+    assert result.loc[0, "interval_coverage_target"] == pytest.approx(0.8)


### PR DESCRIPTION
This PR upgrades the MLB pitcher strikeouts workflow so model evaluation is more useful for betting decisions, not just generic regression reporting.

It adds:

richer training/evaluation metadata
calibrated uncertainty coverage measurement
reproducible workflow-level backtesting utilities
a native historical lines artifact for MLB pitcher strikeouts
integration so training artifacts can report real backtest summaries when historical lines are available
Closes #29
Closes #27

What Changed
Betting-oriented evaluation
Expanded training metadata beyond mae, pred_min, and pred_max
Added richer regression metrics, bucketed error summaries, sample sizes, and interval coverage reporting
Added documented uncertainty calibration based on empirical residual scaling
Reapplied saved interval calibration to daily prediction outputs without breaking existing workflow usage
Native historical lines artifact
Added a curated historical lines dataset path for MLB pitcher strikeouts
Stores one selected line per game_date x player x sportsbook x side
Uses a deterministic v1 selection rule:
latest_pregame_snapshot_per_game_player_book_side
Keeps the interface compatible with future expansion to full snapshot history without requiring consumer refactors
Backtesting integration
Added native-line join support for historical projections/results
Added workflow backtesting against realized outcomes using curated historical lines
Backtest summaries now support breakdowns by:
pick_type
confidence_tier
book
line_band
pick_side
Training/evaluation artifacts now report real workflow backtest summaries when historical lines are present
Scope Notes
This PR intentionally does not add:

full historical snapshot persistence
intraday line movement analysis
open/close delta analysis
timestamp-level replay
multi-sport or multi-prop generalization
dashboard/UI work
Key Files
MLB/src/jobs/build_training_artifacts.py
MLB/src/jobs/build_historical_lines_artifact.py
MLB/src/odds/historical_lines.py
MLB/src/odds/compare.py
MLB/src/odds/backtest.py
MLB/src/pitcher_k/evaluate.py
MLB/src/pitcher_k/predict.py
MLB/src/common/contracts.py
Testing
Targeted test coverage was added for:

historical lines normalization and deterministic selection
artifact writing
historical line joins
reproducible backtesting
training metadata integration
preserved daily prediction behavior
Validated with:

MLB/tests/odds/test_historical_lines.py
MLB/tests/jobs/test_build_historical_lines_artifact.py
MLB/tests/odds/test_compare.py
MLB/tests/odds/test_backtest.py
MLB/tests/jobs/test_build_training_artifacts.py
MLB/tests/jobs/test_run_daily_card.py
MLB/tests/pitcher_k/test_predict.py
Notes for Reviewers
Real workflow backtest summaries depend on raw historical line snapshots being available under MLB/data/raw/historical_lines/
If that source data is absent, the native artifact schema is still produced, but workflow backtest reporting remains unavailable rather than fabricating results