### PR TITLE
Issues/fix model statistical evaluation

### DIFF
--- a/MLB/src/jobs/build_training_artifacts.py
+++ b/MLB/src/jobs/build_training_artifacts.py
@@ -182,6 +182,7 @@ def _build_workflow_backtest_summary(
 def _evaluation_metrics(
     train_output: dict,
     *,
+    train_df: pd.DataFrame,
     test_df: pd.DataFrame,
     historical_lines_df: pd.DataFrame | None = None,
 ) -> dict:
@@ -191,12 +192,12 @@ def _evaluation_metrics(
     y_pred_test = train_output["model"].predict(train_output["dtest"])
 
     test_results = build_prediction_results(
-        train_output["X_test"],
+        test_df,
         y_test,
         y_pred_test,
     )
     interval_config = fit_interval_calibration(
-        train_output["X_train"],
+        train_df,
         y_train,
         y_pred_train,
     )
@@ -208,7 +209,7 @@ def _evaluation_metrics(
             "buckets": build_error_bucket_summary(test_results),
         },
         "uncertainty": summarize_interval_coverage(
-            train_output["X_test"],
+            test_df,
             y_test,
             y_pred_test,
             interval_config,
@@ -257,6 +258,7 @@ def build_training_metadata(
         },
         "evaluation_metrics": _evaluation_metrics(
             train_output,
+            train_df=train_df,
             test_df=test_df,
             historical_lines_df=historical_lines_df,
         ),

--- a/MLB/src/jobs/build_training_artifacts.py
+++ b/MLB/src/jobs/build_training_artifacts.py
@@ -129,6 +129,13 @@ def train_pitcher_k_model(
     starter_like_pitcher_games = filter_starter_like_appearances(pitcher_games)
     model_df = build_model_df(starter_like_pitcher_games)
     train_df, test_df = time_split(model_df)
+
+    if train_df.empty or test_df.empty:
+        raise ValueError(
+            "Starter-like filtering produced an empty train/test split. "
+            f"Expected non-empty rows on both sides of {TRAIN_SPLIT_DATE}."
+        )
+
     train_output = train_model(train_df, test_df)
     metadata = build_training_metadata(
         model_df=model_df,

--- a/MLB/src/pitcher_k/feature_model.py
+++ b/MLB/src/pitcher_k/feature_model.py
@@ -5,6 +5,12 @@ import pandas as pd
 
 from .config import BASE_FEATURES
 
+UNCERTAINTY_FEATURE_COLUMNS = [
+    "strikeouts_stddev_last10",
+    "strikeouts_p25_last10",
+    "strikeouts_p75_last10",
+]
+
 
 def get_feature_columns() -> list[str]:
     """
@@ -27,6 +33,9 @@ def build_model_df(pitcher_games: pd.DataFrame) -> pd.DataFrame:
         "player_name",
         "strikeouts",
     ] + features
+
+    extra_cols = [col for col in UNCERTAINTY_FEATURE_COLUMNS if col in pitcher_games.columns]
+    keep_cols = keep_cols + [col for col in extra_cols if col not in keep_cols]
 
     model_df = pitcher_games[keep_cols].copy()
     model_df["game_date"] = pd.to_datetime(model_df["game_date"])

--- a/MLB/tests/jobs/test_build_training_artifacts.py
+++ b/MLB/tests/jobs/test_build_training_artifacts.py
@@ -1,6 +1,7 @@
 import json
 
 import pandas as pd
+import pytest
 
 from jobs import build_training_artifacts as training_job
 from odds.historical_lines import empty_historical_lines_df
@@ -299,3 +300,61 @@ def test_train_pitcher_k_model_filters_to_starter_like_appearances(monkeypatch):
     assert len(model_df) == 1
     assert model_df["game_pk"].tolist() == [1]
     assert captured["model_df"]["game_pk"].tolist() == [1]
+
+
+def test_train_pitcher_k_model_raises_when_starter_filtering_leaves_empty_held_out_split():
+    pitcher_games = pd.DataFrame(
+        [
+            {
+                "game_date": "2025-07-30",
+                "game_pk": 1,
+                "pitcher": 111,
+                "player_name": "Starter One",
+                "strikeouts": 6,
+                "pitches": 91,
+                "batters_faced": 25,
+                "pitches_last3": 92.0,
+                "pitches_last10": 94.0,
+                "whiff_per_pitch_last3": 0.14,
+                "avg_velo_last3": 97.1,
+                "avg_spin_last3": 2450.0,
+                "k_per_pitch_last10": 0.08,
+                "k_rate_last10": 0.28,
+                "opp_strikeouts_per_game_last10": 9.0,
+                "opp_k_rate_last10": 0.25,
+                "strikeouts_stddev_last10": 1.1,
+                "strikeouts_p25_last10": 5.0,
+                "strikeouts_p75_last10": 7.0,
+            },
+            {
+                "game_date": "2025-08-03",
+                "game_pk": 2,
+                "pitcher": 111,
+                "player_name": "Starter One",
+                "strikeouts": 1,
+                "pitches": 19,
+                "batters_faced": 5,
+                "pitches_last3": 19.0,
+                "pitches_last10": 19.0,
+                "whiff_per_pitch_last3": 0.08,
+                "avg_velo_last3": 96.0,
+                "avg_spin_last3": 2430.0,
+                "k_per_pitch_last10": 0.04,
+                "k_rate_last10": 0.20,
+                "opp_strikeouts_per_game_last10": 8.4,
+                "opp_k_rate_last10": 0.23,
+                "strikeouts_stddev_last10": 0.5,
+                "strikeouts_p25_last10": 1.0,
+                "strikeouts_p75_last10": 1.0,
+            },
+        ]
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="Starter-like filtering produced an empty train/test split",
+    ):
+        training_job.train_pitcher_k_model(
+            pitcher_games,
+            historical_lines_df=empty_historical_lines_df(),
+        )

--- a/MLB/tests/jobs/test_build_training_artifacts.py
+++ b/MLB/tests/jobs/test_build_training_artifacts.py
@@ -93,12 +93,24 @@ def test_promote_latest_to_previous_preserves_matching_metadata(tmp_path, monkey
 def test_build_training_metadata_includes_richer_evaluation_sections():
     model_df = pd.DataFrame(
         [
-            {"game_date": "2025-07-30", "strikeouts": 5},
-            {"game_date": "2025-08-02", "strikeouts": 7},
+            {"game_date": "2025-07-30", "strikeouts": 5, "strikeouts_stddev_last10": 1.1},
+            {"game_date": "2025-07-31", "strikeouts": 6, "strikeouts_stddev_last10": 1.4},
+            {"game_date": "2025-08-02", "strikeouts": 7, "strikeouts_stddev_last10": 1.3},
+            {"game_date": "2025-08-03", "strikeouts": 8, "strikeouts_stddev_last10": 1.5},
         ]
     )
-    train_df = pd.DataFrame([{"game_date": "2025-07-30", "strikeouts": 5}])
-    test_df = pd.DataFrame([{"game_date": "2025-08-02", "strikeouts": 7}])
+    train_df = pd.DataFrame(
+        [
+            {"game_date": "2025-07-30", "strikeouts": 5, "strikeouts_stddev_last10": 1.1},
+            {"game_date": "2025-07-31", "strikeouts": 6, "strikeouts_stddev_last10": 1.4},
+        ]
+    )
+    test_df = pd.DataFrame(
+        [
+            {"game_date": "2025-08-02", "strikeouts": 7, "strikeouts_stddev_last10": 1.3},
+            {"game_date": "2025-08-03", "strikeouts": 8, "strikeouts_stddev_last10": 1.5},
+        ]
+    )
     train_output = {
         "model": FakePredictModel(),
         "dtrain": "train",
@@ -133,7 +145,9 @@ def test_build_training_metadata_includes_richer_evaluation_sections():
     assert "uncertainty" in evaluation
     assert "workflow_backtest" in evaluation
     assert evaluation["workflow_backtest"]["available"] is False
+    assert evaluation["uncertainty"]["mean_interval_width"] > 0
     assert metadata["uncertainty_model"]["interval_multiplier"] > 0
+    assert metadata["uncertainty_model"]["calibration_rows"] > 0
     assert "documented_interpretation" in metadata["uncertainty_model"]
 
 

--- a/MLB/tests/pitcher_k/test_feature_model.py
+++ b/MLB/tests/pitcher_k/test_feature_model.py
@@ -26,11 +26,24 @@ def test_build_model_df_uses_configured_feature_columns():
                 "k_rate_last10": 0.30,
                 "opp_strikeouts_per_game_last10": 9.4,
                 "opp_k_rate_last10": 0.255,
+                "strikeouts_stddev_last10": 1.2,
+                "strikeouts_p25_last10": 6.0,
+                "strikeouts_p75_last10": 9.0,
             }
         ]
     )
 
     model_df = build_model_df(pitcher_games)
 
-    expected_cols = ["game_date", "game_pk", "pitcher", "player_name", "strikeouts"] + BASE_FEATURES
+    expected_cols = [
+        "game_date",
+        "game_pk",
+        "pitcher",
+        "player_name",
+        "strikeouts",
+    ] + BASE_FEATURES + [
+        "strikeouts_stddev_last10",
+        "strikeouts_p25_last10",
+        "strikeouts_p75_last10",
+    ]
     assert list(model_df.columns) == expected_cols


### PR DESCRIPTION
Closes #34

Summary
This PR tightens the MLB pitcher strikeout workflow so starter projections are trained and scored from starter-like appearances only, and fixes the metadata/evaluation path so uncertainty metrics remain trustworthy.

Changes
Added a shared starter-like appearance rule:
pitches >= 40 or batters_faced >= 12
Applied that rule before model training so reliever/opener outings do not pollute the pitcher K model
Applied the same rule when building today/tomorrow starter feature history (hist, last3, last5, last10)
Preserved uncertainty-related columns in the model dataframe
Fixed interval calibration and coverage evaluation to use split dataframes that still contain strikeouts_stddev_last10
Added a fail-fast guard when starter filtering leaves the post-2025-08-01 held-out split empty
Added tests covering:
starter-only training rows
starter-only scoring history
uncertainty metadata calibration behavior
empty held-out split failure mode
Why
Previously, the pitcher K workflow mixed all appearances into both training and recent-history features, which could drag true starter projections down toward reliever-like outcomes. On top of that, uncertainty metadata was being computed from frames that no longer contained the stddev signal used for calibration, producing misleading zero-width or invalid interval metrics.

Validation
Focused pitcher K and training artifact tests pass
Added regression coverage for the new split guard and uncertainty plumbing




10:28 AM