### PR TITLE
Issues/data hardening model backtesting

### DIFF
--- a/.github/workflows/daily-mlb-card.yml
+++ b/.github/workflows/daily-mlb-card.yml
@@ -5,6 +5,9 @@ on:
   schedule:
     - cron: "29 11 * * *" # 7:30 AM ET during EDT
 
+permissions:
+  contents: write
+
 jobs:
   daily-training-card:
     runs-on: ubuntu-latest
@@ -20,6 +23,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - uses: actions/setup-python@v5
         with:
@@ -37,6 +42,20 @@ jobs:
       - name: Run daily card
         run: |
           python -m jobs.run_daily_card
+
+      - name: Commit official picks history
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          if git diff --quiet -- data/tracking/official_picks_history.csv; then
+            echo "No official picks history changes to commit."
+            exit 0
+          fi
+
+          git add data/tracking/official_picks_history.csv
+          git commit -m "Update official picks history"
+          git push
       
       - name: Notify Discord
         if: always()

--- a/.github/workflows/daily-mlb-card.yml
+++ b/.github/workflows/daily-mlb-card.yml
@@ -67,3 +67,4 @@ jobs:
             MLB/data/artifacts/previous/
             MLB/data/inputs/starters/
             MLB/data/outputs/
+            MLB/data/tracking/

--- a/MLB/data/tracking/official_picks_history.csv
+++ b/MLB/data/tracking/official_picks_history.csv
@@ -1,0 +1,32 @@
+pick_key,game_date,player_name,team,opponent,book,odds,price,pick_side,line,predicted_strikeouts,edge,confidence_tier,pick_type,result,actual_strikeouts,record_source
+legacy-0001,,Tyler Bibee,,,DraftKings,+108,108,under,5.5,,,,"official",W,,manual_seed
+legacy-0002,,Kyle Leahy,,,DraftKings,+120,120,under,3.5,,,,"official",L,,manual_seed
+legacy-0003,,Grant Holmes,,,DraftKings,-163,-163,over,4.5,,,,"official",L,,manual_seed
+legacy-0004,,Reid Detmers,,,BetMGM,+100,100,under,5.5,,,,"official",W,,manual_seed
+legacy-0005,,Emerson Hancock,,,DraftKings,-135,-135,under,5.5,,,,"official",W,,manual_seed
+legacy-0006,,Justin Wrobleski,,,DraftKings,-137,-137,under,4.5,,,,"official",W,,manual_seed
+legacy-0007,,Steven Matz,,,BetMGM,-155,-155,under,5.5,,,,"official",W,,manual_seed
+legacy-0008,,Yoshinobu Yamamoto,,,DraftKings,-104,-104,over,5.5,,,,"official",L,,manual_seed
+legacy-0009,,Chris Paddack,,,BetMGM,-135,-135,under,4.5,,,,"official",W,,manual_seed
+legacy-0010,,Eric Lauer,,,DraftKings,+100,100,under,4.5,,,,"official",W,,manual_seed
+legacy-0011,,Anthony Kay,,,DraftKings,-142,-142,under,3.5,,,,"official",W,,manual_seed
+legacy-0012,,Nick Martinez,,,BetMGM,-140,-140,under,4.5,,,,"official",L,,manual_seed
+legacy-0013,,Michael Soroka,,,DraftKings,+103,103,under,5.5,,,,"official",L,,manual_seed
+legacy-0014,,Payton Tolle,,,FanDuel,-110,-110,under,4.5,,,,"official",L,,manual_seed
+legacy-0015,,Lance McCullers Jr,,,BetMGM,-120,-120,under,5.5,,,,"official",W,,manual_seed
+legacy-0016,,Freddy Peralta,,,BetMGM,-150,-150,under,7.5,,,,"official",L,,manual_seed
+legacy-0017,,Sandy Alcantara,,,FanDuel,+136,136,over,4.5,,,,"official",L,,manual_seed
+legacy-0018,,Bryan Woo,,,BetMGM,-185,-185,over,4.5,,,,"official",L,,manual_seed
+legacy-0019,,Jacob Misiorowski,,,BetMGM,-115,-115,under,7.5,,,,"official",L,,manual_seed
+legacy-0020,,Zac Gallen,,,DraftKings,+119,119,over,3.5,,,,"official",Push,,manual_seed
+legacy-0021,,Reid Detmers,,,BetMGM,-120,-120,under,5.5,,,,"official",W,,manual_seed
+legacy-0022,,Carmen Mlodzinski,,,BetMGM,+100,100,under,4.5,,,,"official",W,,manual_seed
+legacy-0023,,Emerson Hancock,,,FanDuel,-154,-154,under,4.5,,,,"official",W,,manual_seed
+legacy-0024,,Luis Castillo,,,BetMGM,-150,-150,over,4.5,,,,"official",L,,manual_seed
+legacy-0025,,Max Fried,,,FanDuel,-125,-125,over,5.5,,,,"official",L,,manual_seed
+legacy-0026,,Matthew Boyd,,,DraftKings,-152,-152,under,5.5,,,,"official",W,,manual_seed
+legacy-0027,,Shohei Ohtani,,,BetMGM,-105,-105,under,6.5,,,,"official",L,,manual_seed
+legacy-0028,,Chad Patrick,,,BetMGM,-150,-150,over,3.5,,,,"official",W,,manual_seed
+legacy-0029,,"Martín Pérez",,,BetMGM,-120,-120,over,3.5,,,,"official",W,,manual_seed
+legacy-0030,,George Kirby,,,FanDuel,+126,126,over,5.5,,,,"official",L,,manual_seed
+legacy-0031,,Yusei Kikuchi,,,BetMGM,+115,115,under,5.5,,,,"official",W,,manual_seed

--- a/MLB/src/jobs/build_training_artifacts.py
+++ b/MLB/src/jobs/build_training_artifacts.py
@@ -203,6 +203,8 @@ def _evaluation_metrics(
         y_test,
         y_pred_test,
     )
+    # Use the full model dataframes here so interval calibration can see
+    # uncertainty columns that are intentionally excluded from BASE_FEATURES.
     interval_config = fit_interval_calibration(
         train_df,
         y_train,
@@ -241,8 +243,10 @@ def build_training_metadata(
     train_output: dict,
     historical_lines_df: pd.DataFrame | None = None,
 ) -> dict:
+    # Calibrate saved intervals from the model dataframe rather than X_train,
+    # because X_train only contains BASE_FEATURES and omits stddev fields.
     uncertainty_model = fit_interval_calibration(
-        train_output["X_train"],
+        train_df,
         train_output["y_train"],
         train_output["model"].predict(train_output["dtrain"]),
     )

--- a/MLB/src/jobs/run_daily_card.py
+++ b/MLB/src/jobs/run_daily_card.py
@@ -35,10 +35,32 @@ PITCHER_GAMES_PATH = LATEST_ARTIFACTS_DIR / "pitcher_games.csv"
 METADATA_FILENAME = "metadata.json"
 
 OUTPUT_DIR = DATA_DIR / "outputs"
+TRACKING_DIR = DATA_DIR / "tracking"
 
 PROJECTIONS_DIR = OUTPUT_DIR / "projections"
 EDGES_DIR = OUTPUT_DIR / "edges"
 PICKS_DIR = OUTPUT_DIR / "picks"
+OFFICIAL_PICKS_HISTORY_PATH = TRACKING_DIR / "official_picks_history.csv"
+
+OFFICIAL_PICKS_HISTORY_COLUMNS = [
+    "pick_key",
+    "game_date",
+    "player_name",
+    "team",
+    "opponent",
+    "book",
+    "odds",
+    "price",
+    "pick_side",
+    "line",
+    "predicted_strikeouts",
+    "edge",
+    "confidence_tier",
+    "pick_type",
+    "result",
+    "actual_strikeouts",
+    "record_source",
+]
 
 BuildPicksFn = Callable[[pd.DataFrame], pd.DataFrame]
 FilterPostablePicksFn = Callable[[pd.DataFrame], pd.DataFrame]
@@ -48,6 +70,128 @@ def ensure_output_dirs() -> None:
     PROJECTIONS_DIR.mkdir(parents=True, exist_ok=True)
     EDGES_DIR.mkdir(parents=True, exist_ok=True)
     PICKS_DIR.mkdir(parents=True, exist_ok=True)
+    TRACKING_DIR.mkdir(parents=True, exist_ok=True)
+
+
+def empty_official_picks_history_df() -> pd.DataFrame:
+    return pd.DataFrame(columns=OFFICIAL_PICKS_HISTORY_COLUMNS)
+
+
+def _format_american_odds(price: float | int | str | None) -> str:
+    if pd.isna(price):
+        return ""
+
+    numeric_price = int(float(price))
+    if numeric_price > 0:
+        return f"+{numeric_price}"
+    return str(numeric_price)
+
+
+def _normalize_pick_key_name(player_name: str) -> str:
+    return " ".join(str(player_name).strip().lower().split())
+
+
+def _build_pick_key(game_date: str, player_name: str) -> str:
+    return f"{game_date}|{_normalize_pick_key_name(player_name)}"
+
+
+def load_official_picks_history() -> pd.DataFrame:
+    if not OFFICIAL_PICKS_HISTORY_PATH.exists():
+        return empty_official_picks_history_df()
+
+    history_df = pd.read_csv(OFFICIAL_PICKS_HISTORY_PATH, keep_default_na=False)
+    missing = [col for col in OFFICIAL_PICKS_HISTORY_COLUMNS if col not in history_df.columns]
+    if missing:
+        raise ValueError(
+            "official_picks_history.csv is missing required columns: "
+            f"{missing}"
+        )
+
+    return history_df[OFFICIAL_PICKS_HISTORY_COLUMNS].copy()
+
+
+def build_official_picks_history_rows(
+    starters_df: pd.DataFrame,
+    post_df: pd.DataFrame,
+) -> pd.DataFrame:
+    official_df = post_df[post_df["pick_type"] == "official"].copy()
+    if official_df.empty:
+        return empty_official_picks_history_df()
+
+    starter_lookup = starters_df[
+        ["player_name", "team", "opponent", "game_date"]
+    ].copy()
+    starter_lookup["game_date"] = pd.to_datetime(starter_lookup["game_date"]).dt.strftime("%Y-%m-%d")
+    merge_keys = ["player_name"]
+    if {"team", "opponent"}.issubset(official_df.columns):
+        merge_keys = ["player_name", "team", "opponent"]
+
+    starter_lookup = starter_lookup.drop_duplicates(subset=merge_keys, keep="last")
+
+    history_rows = official_df.merge(
+        starter_lookup,
+        on=merge_keys,
+        how="left",
+    )
+
+    if history_rows["game_date"].isna().any():
+        unique_game_dates = pd.to_datetime(starters_df["game_date"]).dt.strftime("%Y-%m-%d").dropna().unique()
+        if len(unique_game_dates) == 1:
+            history_rows["game_date"] = history_rows["game_date"].fillna(unique_game_dates[0])
+
+    history_rows["game_date"] = history_rows["game_date"].fillna("").astype(str)
+    history_rows["pick_key"] = history_rows.apply(
+        lambda row: _build_pick_key(row["game_date"], row["player_name"]),
+        axis=1,
+    )
+    history_rows["odds"] = history_rows["price"].apply(_format_american_odds)
+    history_rows["result"] = ""
+    history_rows["actual_strikeouts"] = ""
+    history_rows["record_source"] = "run_daily_card"
+
+    for column in OFFICIAL_PICKS_HISTORY_COLUMNS:
+        if column not in history_rows.columns:
+            history_rows[column] = ""
+
+    return history_rows[OFFICIAL_PICKS_HISTORY_COLUMNS].copy()
+
+
+def persist_official_picks_history(
+    starters_df: pd.DataFrame,
+    post_df: pd.DataFrame,
+) -> Path:
+    existing_df = load_official_picks_history()
+    new_rows = build_official_picks_history_rows(starters_df, post_df)
+
+    if new_rows.empty:
+        if not OFFICIAL_PICKS_HISTORY_PATH.exists():
+            existing_df.to_csv(OFFICIAL_PICKS_HISTORY_PATH, index=False)
+        return OFFICIAL_PICKS_HISTORY_PATH
+
+    existing_by_key = existing_df.set_index("pick_key", drop=False)
+    merged_rows: list[dict] = []
+
+    for _, new_row in new_rows.iterrows():
+        new_record = new_row.to_dict()
+        pick_key = new_record["pick_key"]
+
+        if pick_key in existing_by_key.index:
+            existing_record = existing_by_key.loc[pick_key].to_dict()
+            if existing_record.get("result") and not new_record.get("result"):
+                new_record["result"] = existing_record["result"]
+            if existing_record.get("actual_strikeouts") and not new_record.get("actual_strikeouts"):
+                new_record["actual_strikeouts"] = existing_record["actual_strikeouts"]
+            if existing_record.get("record_source") and not new_record.get("record_source"):
+                new_record["record_source"] = existing_record["record_source"]
+
+        merged_rows.append(new_record)
+
+    merged_df = pd.DataFrame(merged_rows, columns=OFFICIAL_PICKS_HISTORY_COLUMNS)
+    untouched_existing = existing_df[~existing_df["pick_key"].isin(merged_df["pick_key"])]
+    history_df = pd.concat([untouched_existing, merged_df], ignore_index=True)
+    history_df = history_df[OFFICIAL_PICKS_HISTORY_COLUMNS]
+    history_df.to_csv(OFFICIAL_PICKS_HISTORY_PATH, index=False)
+    return OFFICIAL_PICKS_HISTORY_PATH
 
 
 def resolve_artifact_path(filename: str) -> Path:
@@ -162,6 +306,7 @@ def save_outputs(
     joined_df.to_csv(EDGES_DIR / "today_joined_edges.csv", index=False)
     picks_df.to_csv(PICKS_DIR / "today_all_picks.csv", index=False)
     post_df.to_csv(PICKS_DIR / "today_postable_picks.csv", index=False)
+    persist_official_picks_history(starters_df, post_df)
 
 
 def run_daily_card(

--- a/MLB/src/pitcher_k/evaluate.py
+++ b/MLB/src/pitcher_k/evaluate.py
@@ -12,8 +12,8 @@ def evaluate_predictions(y_true, y_pred) -> dict:
     """
     Return richer regression metrics for model governance.
     """
-    y_true_series = pd.Series(y_true, dtype="float64")
-    y_pred_series = pd.Series(y_pred, dtype="float64")
+    y_true_series = pd.Series(y_true, dtype="float64").reset_index(drop=True)
+    y_pred_series = pd.Series(y_pred, dtype="float64").reset_index(drop=True)
     errors = y_pred_series - y_true_series
     abs_errors = errors.abs()
 

--- a/MLB/src/pitcher_k/feature_engineering.py
+++ b/MLB/src/pitcher_k/feature_engineering.py
@@ -270,7 +270,7 @@ def add_opponent_k_features(pitcher_games: pd.DataFrame, sc: pd.DataFrame) -> pd
 
 def add_rolling_pitcher_features(pitcher_games: pd.DataFrame) -> pd.DataFrame:
     """
-    Add trailing 3-game and 10-game rolling averages using prior games only.
+    Add trailing rolling features using prior games only.
     """
     require_columns(
         pitcher_games,
@@ -310,6 +310,17 @@ def add_rolling_pitcher_features(pitcher_games: pd.DataFrame) -> pd.DataFrame:
             .transform(lambda s: s.shift(1).rolling(10, min_periods=3).mean())
         )
 
+    strikeouts_history = pitcher_games.groupby("pitcher")["strikeouts"].transform(
+        lambda s: s.shift(1).rolling(10, min_periods=3).std(ddof=0)
+    )
+    pitcher_games["strikeouts_stddev_last10"] = strikeouts_history
+    pitcher_games["strikeouts_p25_last10"] = pitcher_games.groupby("pitcher")["strikeouts"].transform(
+        lambda s: s.shift(1).rolling(10, min_periods=3).quantile(0.25)
+    )
+    pitcher_games["strikeouts_p75_last10"] = pitcher_games.groupby("pitcher")["strikeouts"].transform(
+        lambda s: s.shift(1).rolling(10, min_periods=3).quantile(0.75)
+    )
+
     require_columns(
         pitcher_games,
         [
@@ -320,6 +331,9 @@ def add_rolling_pitcher_features(pitcher_games: pd.DataFrame) -> pd.DataFrame:
             "avg_spin_last3",
             "strikeouts_last10",
             "batters_faced_last10",
+            "strikeouts_stddev_last10",
+            "strikeouts_p25_last10",
+            "strikeouts_p75_last10",
         ],
         "pitcher_games",
     )

--- a/MLB/tests/jobs/test_build_training_artifacts.py
+++ b/MLB/tests/jobs/test_build_training_artifacts.py
@@ -118,14 +118,14 @@ def test_build_training_metadata_includes_richer_evaluation_sections():
         "dtest": "test",
         "X_train": pd.DataFrame(
             [
-                {"pitches_last3": 90.0, "strikeouts_stddev_last10": 1.1},
-                {"pitches_last3": 95.0, "strikeouts_stddev_last10": 1.4},
+                {"pitches_last3": 90.0},
+                {"pitches_last3": 95.0},
             ]
         ),
         "X_test": pd.DataFrame(
             [
-                {"pitches_last3": 92.0, "strikeouts_stddev_last10": 1.2},
-                {"pitches_last3": 98.0, "strikeouts_stddev_last10": 1.5},
+                {"pitches_last3": 92.0},
+                {"pitches_last3": 98.0},
             ]
         ),
         "y_train": pd.Series([5.0, 6.0], dtype="float64"),
@@ -175,13 +175,13 @@ def test_build_training_metadata_uses_native_historical_lines_for_real_backtest(
         "dtest": "test",
         "X_train": pd.DataFrame(
             [
-                {"pitches_last3": 90.0, "strikeouts_stddev_last10": 1.1},
-                {"pitches_last3": 95.0, "strikeouts_stddev_last10": 1.4},
+                {"pitches_last3": 90.0},
+                {"pitches_last3": 95.0},
             ]
         ),
         "X_test": pd.DataFrame(
             [
-                {"pitches_last3": 92.0, "strikeouts_stddev_last10": 1.2},
+                {"pitches_last3": 92.0},
             ]
         ),
         "y_train": pd.Series([5.0, 6.0], dtype="float64"),

--- a/MLB/tests/jobs/test_run_daily_card.py
+++ b/MLB/tests/jobs/test_run_daily_card.py
@@ -121,6 +121,12 @@ def test_run_daily_card_writes_outputs_with_mocked_dependencies(monkeypatch, tmp
     monkeypatch.setattr(daily_card, "PROJECTIONS_DIR", tmp_path / "data" / "outputs" / "projections")
     monkeypatch.setattr(daily_card, "EDGES_DIR", tmp_path / "data" / "outputs" / "edges")
     monkeypatch.setattr(daily_card, "PICKS_DIR", tmp_path / "data" / "outputs" / "picks")
+    monkeypatch.setattr(daily_card, "TRACKING_DIR", tmp_path / "data" / "tracking")
+    monkeypatch.setattr(
+        daily_card,
+        "OFFICIAL_PICKS_HISTORY_PATH",
+        tmp_path / "data" / "tracking" / "official_picks_history.csv",
+    )
 
     saved_starters = {}
 
@@ -146,11 +152,17 @@ def test_run_daily_card_writes_outputs_with_mocked_dependencies(monkeypatch, tmp
     assert (daily_card.EDGES_DIR / "today_joined_edges.csv").exists()
     assert (daily_card.PICKS_DIR / "today_all_picks.csv").exists()
     assert (daily_card.PICKS_DIR / "today_postable_picks.csv").exists()
+    assert daily_card.OFFICIAL_PICKS_HISTORY_PATH.exists()
 
     loaded_post = pd.read_csv(daily_card.PICKS_DIR / "today_postable_picks.csv")
+    loaded_history = pd.read_csv(daily_card.OFFICIAL_PICKS_HISTORY_PATH, keep_default_na=False)
     assert len(loaded_post) == 1
     assert loaded_post.loc[0, "player_name"] == "Jacob deGrom"
     assert loaded_post.loc[0, "pick_type"] == "official"
+    assert len(loaded_history) == 1
+    assert loaded_history.loc[0, "game_date"] == "2026-04-19"
+    assert str(loaded_history.loc[0, "odds"]) == "-120"
+    assert loaded_history.loc[0, "pick_key"] == "2026-04-19|jacob degrom"
 
 
 def test_run_daily_card_allows_explicit_market_and_workflow_behavior(monkeypatch, tmp_path):
@@ -247,6 +259,12 @@ def test_run_daily_card_allows_explicit_market_and_workflow_behavior(monkeypatch
     monkeypatch.setattr(daily_card, "PROJECTIONS_DIR", tmp_path / "data" / "outputs" / "projections")
     monkeypatch.setattr(daily_card, "EDGES_DIR", tmp_path / "data" / "outputs" / "edges")
     monkeypatch.setattr(daily_card, "PICKS_DIR", tmp_path / "data" / "outputs" / "picks")
+    monkeypatch.setattr(daily_card, "TRACKING_DIR", tmp_path / "data" / "tracking")
+    monkeypatch.setattr(
+        daily_card,
+        "OFFICIAL_PICKS_HISTORY_PATH",
+        tmp_path / "data" / "tracking" / "official_picks_history.csv",
+    )
     monkeypatch.setattr(daily_card, "save_today_starters_csv", lambda df, output_dir=None, filename=None: tmp_path / "today_starters.csv")
 
     custom_market = "custom_market"
@@ -335,6 +353,12 @@ def test_run_daily_card_raises_when_today_predictions_are_empty(monkeypatch, tmp
     monkeypatch.setattr(daily_card, "PROJECTIONS_DIR", tmp_path / "data" / "outputs" / "projections")
     monkeypatch.setattr(daily_card, "EDGES_DIR", tmp_path / "data" / "outputs" / "edges")
     monkeypatch.setattr(daily_card, "PICKS_DIR", tmp_path / "data" / "outputs" / "picks")
+    monkeypatch.setattr(daily_card, "TRACKING_DIR", tmp_path / "data" / "tracking")
+    monkeypatch.setattr(
+        daily_card,
+        "OFFICIAL_PICKS_HISTORY_PATH",
+        tmp_path / "data" / "tracking" / "official_picks_history.csv",
+    )
 
     with pytest.raises(ValueError, match="No today predictions were generated."):
         daily_card.run_daily_card()
@@ -369,6 +393,12 @@ def test_run_daily_card_raises_when_pitcher_games_artifact_is_missing(monkeypatc
     monkeypatch.setattr(daily_card, "PROJECTIONS_DIR", tmp_path / "data" / "outputs" / "projections")
     monkeypatch.setattr(daily_card, "EDGES_DIR", tmp_path / "data" / "outputs" / "edges")
     monkeypatch.setattr(daily_card, "PICKS_DIR", tmp_path / "data" / "outputs" / "picks")
+    monkeypatch.setattr(daily_card, "TRACKING_DIR", tmp_path / "data" / "tracking")
+    monkeypatch.setattr(
+        daily_card,
+        "OFFICIAL_PICKS_HISTORY_PATH",
+        tmp_path / "data" / "tracking" / "official_picks_history.csv",
+    )
 
     with pytest.raises(FileNotFoundError, match="Missing pitcher_games artifact"):
         daily_card.run_daily_card()
@@ -479,6 +509,12 @@ def test_run_daily_card_uses_workflow_spec_for_market_policy_and_limits(monkeypa
     monkeypatch.setattr(daily_card, "PROJECTIONS_DIR", tmp_path / "data" / "outputs" / "projections")
     monkeypatch.setattr(daily_card, "EDGES_DIR", tmp_path / "data" / "outputs" / "edges")
     monkeypatch.setattr(daily_card, "PICKS_DIR", tmp_path / "data" / "outputs" / "picks")
+    monkeypatch.setattr(daily_card, "TRACKING_DIR", tmp_path / "data" / "tracking")
+    monkeypatch.setattr(
+        daily_card,
+        "OFFICIAL_PICKS_HISTORY_PATH",
+        tmp_path / "data" / "tracking" / "official_picks_history.csv",
+    )
     monkeypatch.setattr(daily_card, "save_today_starters_csv", lambda df, output_dir=None, filename=None: tmp_path / "today_starters.csv")
 
     def fake_run_edge_pipeline(preds, market, **kwargs):
@@ -510,6 +546,85 @@ def test_run_daily_card_uses_workflow_spec_for_market_policy_and_limits(monkeypa
     assert calls["build_policy"] is workflow.pick_ranking_policy
     assert calls["filter_policy"] is workflow.pick_ranking_policy
     assert calls["filter_limits"] == (1, 0)
+
+
+def test_persist_official_picks_history_is_idempotent_and_preserves_manual_results(tmp_path, monkeypatch):
+    starters_df = pd.DataFrame(
+        [
+            {
+                "game_date": "2026-04-19",
+                "game_pk": 123456,
+                "pitcher": 1,
+                "player_name": "Jacob deGrom",
+                "team": "TEX",
+                "opponent": "SEA",
+                "home_team": "TEX",
+                "away_team": "SEA",
+                "is_home": 1,
+                "p_throws": "R",
+            }
+        ]
+    )
+    post_df = pd.DataFrame(
+        [
+            {
+                "player_name": "Jacob deGrom",
+                "team": "TEX",
+                "opponent": "SEA",
+                "predicted_strikeouts": 6.8,
+                "book": "DraftKings",
+                "pick_side": "over",
+                "line": 5.5,
+                "price": -120,
+                "edge": 1.3,
+                "confidence_tier": "medium",
+                "pick_type": "official",
+            }
+        ]
+    )
+
+    tracking_dir = tmp_path / "data" / "tracking"
+    history_path = tracking_dir / "official_picks_history.csv"
+
+    monkeypatch.setattr(daily_card, "TRACKING_DIR", tracking_dir)
+    monkeypatch.setattr(daily_card, "OFFICIAL_PICKS_HISTORY_PATH", history_path)
+    tracking_dir.mkdir(parents=True, exist_ok=True)
+
+    seed_history = pd.DataFrame(
+        [
+            {
+                "pick_key": "2026-04-19|jacob degrom",
+                "game_date": "2026-04-19",
+                "player_name": "Jacob deGrom",
+                "team": "TEX",
+                "opponent": "SEA",
+                "book": "DraftKings",
+                "odds": "-120",
+                "price": -120,
+                "pick_side": "over",
+                "line": 5.5,
+                "predicted_strikeouts": 6.6,
+                "edge": 1.1,
+                "confidence_tier": "medium",
+                "pick_type": "official",
+                "result": "W",
+                "actual_strikeouts": "7",
+                "record_source": "manual_seed",
+            }
+        ]
+    )
+    seed_history.to_csv(history_path, index=False)
+
+    daily_card.persist_official_picks_history(starters_df, post_df)
+    daily_card.persist_official_picks_history(starters_df, post_df)
+
+    loaded_history = pd.read_csv(history_path, keep_default_na=False)
+
+    assert len(loaded_history) == 1
+    assert loaded_history.loc[0, "result"] == "W"
+    assert str(loaded_history.loc[0, "actual_strikeouts"]) == "7"
+    assert loaded_history.loc[0, "predicted_strikeouts"] == pytest.approx(6.8)
+    assert loaded_history.loc[0, "edge"] == pytest.approx(1.3)
 
 
 def test_load_model_metadata_reads_matching_file_from_selected_artifact_dir(tmp_path, monkeypatch, capsys):

--- a/MLB/tests/pitcher_k/test_evaluate.py
+++ b/MLB/tests/pitcher_k/test_evaluate.py
@@ -1,0 +1,24 @@
+import math
+
+import pandas as pd
+import pytest
+
+from pitcher_k.evaluate import evaluate_predictions
+
+
+def test_evaluate_predictions_ignores_input_index_alignment():
+    y_true = pd.Series([5.0, 8.0], index=[10, 11], dtype="float64")
+    y_pred = pd.Series([5.4, 7.1], index=[0, 1], dtype="float64")
+
+    metrics = evaluate_predictions(y_true, y_pred)
+
+    assert metrics["mae"] == pytest.approx(0.65)
+    assert math.isclose(metrics["rmse"], math.sqrt((0.4 ** 2 + (-0.9) ** 2) / 2))
+    assert metrics["median_absolute_error"] == pytest.approx(0.65)
+    assert metrics["bias"] == pytest.approx(-0.25)
+    assert metrics["abs_error_p75"] == pytest.approx(0.775)
+    assert metrics["abs_error_p90"] == pytest.approx(0.85)
+    assert metrics["pred_min"] == pytest.approx(5.4)
+    assert metrics["pred_max"] == pytest.approx(7.1)
+    assert metrics["actual_min"] == pytest.approx(5.0)
+    assert metrics["actual_max"] == pytest.approx(8.0)

--- a/MLB/tests/pitcher_k/test_feature_engineering.py
+++ b/MLB/tests/pitcher_k/test_feature_engineering.py
@@ -158,8 +158,42 @@ def test_add_rolling_pitcher_features_creates_critical_rolling_columns():
         "avg_spin_last3",
         "strikeouts_last10",
         "batters_faced_last10",
+        "strikeouts_stddev_last10",
+        "strikeouts_p25_last10",
+        "strikeouts_p75_last10",
     }
     assert expected_cols.issubset(enriched.columns)
+
+
+def test_add_rolling_pitcher_features_builds_uncertainty_history_from_prior_games():
+    sc = _statcast_df()
+    pitcher_games = build_pitcher_game_table(sc)
+    pitcher_games = add_pitcher_team_info(pitcher_games, sc)
+    pitcher_games = add_opponent_k_features(pitcher_games, sc)
+
+    # Give one pitcher varying strikeout totals so the trailing stddev is non-zero.
+    strikeout_pattern = {
+        1001: 1,
+        1002: 3,
+        1003: 2,
+        1004: 4,
+    }
+    pitcher_games.loc[pitcher_games["pitcher"] == 111, "strikeouts"] = (
+        pitcher_games.loc[pitcher_games["pitcher"] == 111, "game_pk"].map(strikeout_pattern)
+    )
+
+    enriched = add_rolling_pitcher_features(pitcher_games)
+    degrom_rows = enriched[enriched["pitcher"] == 111].sort_values("game_pk").reset_index(drop=True)
+
+    assert pd.isna(degrom_rows.loc[0, "strikeouts_stddev_last10"])
+    assert pd.isna(degrom_rows.loc[1, "strikeouts_stddev_last10"])
+    assert degrom_rows.loc[3, "strikeouts_stddev_last10"] == pytest.approx(
+        pd.Series([1.0, 3.0, 2.0]).std(ddof=0)
+    )
+    assert pd.isna(degrom_rows.loc[2, "strikeouts_p25_last10"])
+    assert pd.isna(degrom_rows.loc[2, "strikeouts_p75_last10"])
+    assert degrom_rows.loc[3, "strikeouts_p25_last10"] == pytest.approx(1.5)
+    assert degrom_rows.loc[3, "strikeouts_p75_last10"] == pytest.approx(2.5)
 
 
 def test_add_rate_features_creates_required_rate_columns():


### PR DESCRIPTION
This PR improves the MLB daily card pipeline by fixing broken model evaluation, restoring usable uncertainty intervals, and adding persistent tracking for official picks.

It includes three main changes:

Fixes the regression-metrics bug where evaluate_predictions() could produce NaN values because Pandas was aligning y_true and y_pred by index instead of position.
Repairs uncertainty calibration by generating historical strikeouts_stddev_last10 / percentile fields in the training pipeline and calibrating from train_df rather than the reduced X_train feature matrix.
Adds a persistent official_picks_history.csv ledger, seeds it with the existing official pick record, updates run_daily_card to append new official picks idempotently, and updates the daily GitHub Actions workflow to commit the ledger back to the repo after successful runs.
Tests were added/updated around metric evaluation, rolling uncertainty features, training metadata calibration, and daily card output persistence.