### PR TITLE
Refactor/pitcher k mlb logic

### DIFF
--- a/MLB/src/common/workflows.py
+++ b/MLB/src/common/workflows.py
@@ -12,6 +12,7 @@ FeatureBuilder = Callable[[pd.DataFrame, pd.DataFrame], pd.DataFrame]
 Predictor = Callable[[object, pd.DataFrame], pd.DataFrame]
 ArtifactDataLoader = Callable[[Path], pd.DataFrame]
 ArtifactModelLoader = Callable[[Path], object]
+PredictionMetadataAdjuster = Callable[[pd.DataFrame, dict | None], pd.DataFrame]
 
 
 @dataclass(frozen=True)
@@ -40,6 +41,7 @@ class ModelingWorkflowSpec:
     projection_odds_join_keys: ProjectionOddsJoinKeys
     pick_ranking_policy: PickRankingPolicy
     prediction_columns: tuple[str, ...]
+    prediction_metadata_adjuster: PredictionMetadataAdjuster | None = None
     postable_limits: PostablePickLimits = field(default_factory=PostablePickLimits)
 
     def resolved_postable_limits(self) -> PostablePickLimits:

--- a/MLB/src/common/workflows.py
+++ b/MLB/src/common/workflows.py
@@ -1,22 +1,17 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import Callable
 
 import pandas as pd
 
-from odds.policy import (
-    DEFAULT_MLB_PITCHER_STRIKEOUT_POLICY,
-    PickRankingPolicy,
-    PostablePickLimits,
-)
-from pitcher_k.config import PITCHER_K_PROP_MARKET
-from pitcher_k.feature_engineering import build_team_context
-from pitcher_k.feature_tomorrow import build_tomorrow_features
-from pitcher_k.predict import predict_on_dataframe
+from odds.policy import PickRankingPolicy, PostablePickLimits
 
 FeatureBuilder = Callable[[pd.DataFrame, pd.DataFrame], pd.DataFrame]
 Predictor = Callable[[object, pd.DataFrame], pd.DataFrame]
+ArtifactDataLoader = Callable[[Path], pd.DataFrame]
+ArtifactModelLoader = Callable[[Path], object]
 
 
 @dataclass(frozen=True)
@@ -26,46 +21,26 @@ class ProjectionOddsJoinKeys:
 
 
 @dataclass(frozen=True)
+class WorkflowArtifactSpec:
+    history_filename: str
+    history_loader: ArtifactDataLoader
+    model_filename: str
+    model_loader: ArtifactModelLoader
+    metadata_filename: str = "metadata.json"
+
+
+@dataclass(frozen=True)
 class ModelingWorkflowSpec:
     sport: str
     participant_key: str
     market_key: str
+    artifacts: WorkflowArtifactSpec
     feature_builder: FeatureBuilder
     predictor: Predictor
     projection_odds_join_keys: ProjectionOddsJoinKeys
     pick_ranking_policy: PickRankingPolicy
+    prediction_columns: tuple[str, ...]
     postable_limits: PostablePickLimits = field(default_factory=PostablePickLimits)
 
     def resolved_postable_limits(self) -> PostablePickLimits:
         return self.postable_limits
-
-
-def build_mlb_pitcher_strikeout_features(
-    starters_df: pd.DataFrame,
-    pitcher_games: pd.DataFrame,
-) -> pd.DataFrame:
-    as_of_date = starters_df["game_date"].min()
-    team_context = build_team_context(pitcher_games, as_of_date=as_of_date)
-    return build_tomorrow_features(
-        slate_df=starters_df,
-        pitcher_games=pitcher_games,
-        team_context=team_context,
-    )
-
-
-MLB_PITCHER_STRIKEOUT_WORKFLOW = ModelingWorkflowSpec(
-    sport="MLB",
-    participant_key="player_name",
-    market_key=PITCHER_K_PROP_MARKET,
-    feature_builder=build_mlb_pitcher_strikeout_features,
-    predictor=predict_on_dataframe,
-    projection_odds_join_keys=ProjectionOddsJoinKeys(
-        projection="player_name_norm",
-        odds="player_name_norm",
-    ),
-    pick_ranking_policy=DEFAULT_MLB_PITCHER_STRIKEOUT_POLICY,
-    postable_limits=PostablePickLimits(
-        max_official=3,
-        max_leans=1,
-    ),
-)

--- a/MLB/src/jobs/run_daily_card.py
+++ b/MLB/src/jobs/run_daily_card.py
@@ -23,7 +23,6 @@ from common.contracts import (
     require_columns,
 )
 from common.workflows import ModelingWorkflowSpec
-from pitcher_k.evaluate import apply_interval_calibration
 from pitcher_k.workflow import MLB_PITCHER_STRIKEOUT_WORKFLOW
 
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
@@ -31,8 +30,6 @@ DATA_DIR = PROJECT_ROOT / "data"
 ARTIFACTS_DIR = DATA_DIR / "artifacts"
 LATEST_ARTIFACTS_DIR = ARTIFACTS_DIR / "latest"
 PREVIOUS_ARTIFACTS_DIR = ARTIFACTS_DIR / "previous"
-
-METADATA_FILENAME = "metadata.json"
 
 OUTPUT_DIR = DATA_DIR / "outputs"
 TRACKING_DIR = DATA_DIR / "tracking"
@@ -136,7 +133,7 @@ def build_official_picks_history_rows(
         merge_keys = ["player_name", "team", "opponent"]
 
     starter_lookup = starter_lookup.drop_duplicates(subset=merge_keys, keep="last")
-history_rows = official_df.merge(
+    history_rows = official_df.merge(
         starter_lookup,
         on=merge_keys,
         how="left",
@@ -309,18 +306,13 @@ def build_today_predictions_for_workflow(
 def apply_metadata_uncertainty(
     today_preds: pd.DataFrame,
     metadata: dict | None,
+    workflow: ModelingWorkflowSpec = MLB_PITCHER_STRIKEOUT_WORKFLOW,
 ) -> pd.DataFrame:
-    """
-    Re-apply interval bounds using the saved calibration config when available.
-    """
-    if today_preds.empty:
+    adjuster = workflow.prediction_metadata_adjuster
+    if adjuster is None:
         return today_preds
 
-    interval_config = (metadata or {}).get("uncertainty_model")
-    if not interval_config:
-        return today_preds
-
-    return apply_interval_calibration(today_preds, interval_config)
+    return adjuster(today_preds, metadata)
 
 
 def save_run_status(*, status: str, message: str | None = None) -> None:
@@ -390,7 +382,7 @@ def run_daily_card(
         model=model,
         workflow=workflow,
     )
-    today_preds = apply_metadata_uncertainty(today_preds, metadata)
+    today_preds = apply_metadata_uncertainty(today_preds, metadata, workflow)
 
     if today_preds.empty:
         raise ValueError("No today predictions were generated.")

--- a/MLB/src/jobs/run_daily_card.py
+++ b/MLB/src/jobs/run_daily_card.py
@@ -8,7 +8,6 @@ from typing import Callable
 
 import pandas as pd
 import requests
-import xgboost as xgb
 
 from starters.today_starters import get_today_starters_df, save_today_starters_csv
 
@@ -18,14 +17,14 @@ from common.contracts import (
     FINAL_PICKS_REQUIRED_COLUMNS,
     JOINED_ODDS_REQUIRED_COLUMNS,
     validate_starters_contract,
-    validate_pitcher_games_contract,
     validate_joined_odds_contract,
     validate_final_picks_contract,
     assert_non_empty,
     require_columns,
 )
-from common.workflows import MLB_PITCHER_STRIKEOUT_WORKFLOW, ModelingWorkflowSpec
+from common.workflows import ModelingWorkflowSpec
 from pitcher_k.evaluate import apply_interval_calibration
+from pitcher_k.workflow import MLB_PITCHER_STRIKEOUT_WORKFLOW
 
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
 DATA_DIR = PROJECT_ROOT / "data"
@@ -33,8 +32,6 @@ ARTIFACTS_DIR = DATA_DIR / "artifacts"
 LATEST_ARTIFACTS_DIR = ARTIFACTS_DIR / "latest"
 PREVIOUS_ARTIFACTS_DIR = ARTIFACTS_DIR / "previous"
 
-MODEL_PATH = LATEST_ARTIFACTS_DIR / "model.ubj"
-PITCHER_GAMES_PATH = LATEST_ARTIFACTS_DIR / "pitcher_games.csv"
 METADATA_FILENAME = "metadata.json"
 
 OUTPUT_DIR = DATA_DIR / "outputs"
@@ -139,8 +136,7 @@ def build_official_picks_history_rows(
         merge_keys = ["player_name", "team", "opponent"]
 
     starter_lookup = starter_lookup.drop_duplicates(subset=merge_keys, keep="last")
-
-    history_rows = official_df.merge(
+history_rows = official_df.merge(
         starter_lookup,
         on=merge_keys,
         how="left",
@@ -247,26 +243,23 @@ def resolve_artifact_path(filename: str) -> Path:
     )
 
 
-def load_pitcher_games_artifact() -> pd.DataFrame:
-    path = resolve_artifact_path("pitcher_games.csv")
-    pitcher_games = pd.read_csv(path)
-    pitcher_games["game_date"] = pd.to_datetime(pitcher_games["game_date"])
-    validate_pitcher_games_contract(pitcher_games)
-    print(f"Loaded pitcher_games artifact from: {path}")
-    return pitcher_games
+def load_workflow_history_artifact(workflow: ModelingWorkflowSpec) -> pd.DataFrame:
+    path = resolve_artifact_path(workflow.artifacts.history_filename)
+    history_df = workflow.artifacts.history_loader(path)
+    print(f"Loaded workflow history artifact from: {path}")
+    return history_df
 
 
-def load_model_artifact():
-    path = resolve_artifact_path("model.ubj")
-    model = xgb.Booster()
-    model.load_model(str(path))
+def load_workflow_model_artifact(workflow: ModelingWorkflowSpec):
+    path = resolve_artifact_path(workflow.artifacts.model_filename)
+    model = workflow.artifacts.model_loader(path)
     print(f"Loaded model artifact from: {path}")
     return model
 
 
-def load_model_metadata() -> dict:
-    model_path = resolve_artifact_path("model.ubj")
-    metadata_path = model_path.with_name(METADATA_FILENAME)
+def load_model_metadata(workflow: ModelingWorkflowSpec = MLB_PITCHER_STRIKEOUT_WORKFLOW) -> dict:
+    model_path = resolve_artifact_path(workflow.artifacts.model_filename)
+    metadata_path = model_path.with_name(workflow.artifacts.metadata_filename)
 
     if not metadata_path.exists():
         raise FileNotFoundError(
@@ -297,7 +290,6 @@ def build_today_predictions_for_workflow(
     workflow: ModelingWorkflowSpec,
 ):
     validate_starters_contract(starters_df)
-    validate_pitcher_games_contract(pitcher_games)
 
     today_features = workflow.feature_builder(starters_df, pitcher_games)
 
@@ -308,7 +300,7 @@ def build_today_predictions_for_workflow(
     assert_non_empty(today_preds, "today_preds")
     require_columns(
         today_preds,
-        ["player_name", "predicted_strikeouts", "lower_bound", "upper_bound", "std_dev"],
+        list(workflow.prediction_columns),
         "today_preds",
     )
     return today_preds
@@ -388,13 +380,13 @@ def run_daily_card(
 
     starters_df = get_today_starters_df()
     validate_starters_contract(starters_df)
-    pitcher_games = load_pitcher_games_artifact()
-    model = load_model_artifact()
-    metadata = load_model_metadata()
+    history_df = load_workflow_history_artifact(workflow)
+    model = load_workflow_model_artifact(workflow)
+    metadata = load_model_metadata(workflow)
 
     today_preds = build_today_predictions_for_workflow(
         starters_df=starters_df,
-        pitcher_games=pitcher_games,
+        pitcher_games=history_df,
         model=model,
         workflow=workflow,
     )

--- a/MLB/src/pitcher_k/workflow.py
+++ b/MLB/src/pitcher_k/workflow.py
@@ -13,6 +13,7 @@ from common.workflows import (
 )
 from odds.policy import DEFAULT_MLB_PITCHER_STRIKEOUT_POLICY, PostablePickLimits
 from pitcher_k.config import PITCHER_K_PROP_MARKET
+from pitcher_k.evaluate import apply_interval_calibration
 from pitcher_k.feature_engineering import build_team_context
 from pitcher_k.feature_tomorrow import build_tomorrow_features
 from pitcher_k.predict import predict_on_dataframe
@@ -44,6 +45,20 @@ def build_mlb_pitcher_strikeout_features(
     )
 
 
+def apply_pitcher_k_metadata_uncertainty(
+    today_preds: pd.DataFrame,
+    metadata: dict | None,
+) -> pd.DataFrame:
+    if today_preds.empty:
+        return today_preds
+
+    interval_config = (metadata or {}).get("uncertainty_model")
+    if not interval_config:
+        return today_preds
+
+    return apply_interval_calibration(today_preds, interval_config)
+
+
 MLB_PITCHER_STRIKEOUT_WORKFLOW = ModelingWorkflowSpec(
     sport="MLB",
     participant_key="player_name",
@@ -68,6 +83,7 @@ MLB_PITCHER_STRIKEOUT_WORKFLOW = ModelingWorkflowSpec(
         "upper_bound",
         "std_dev",
     ),
+    prediction_metadata_adjuster=apply_pitcher_k_metadata_uncertainty,
     postable_limits=PostablePickLimits(
         max_official=3,
         max_leans=1,

--- a/MLB/src/pitcher_k/workflow.py
+++ b/MLB/src/pitcher_k/workflow.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandas as pd
+import xgboost as xgb
+
+from common.contracts import validate_pitcher_games_contract
+from common.workflows import (
+    ModelingWorkflowSpec,
+    ProjectionOddsJoinKeys,
+    WorkflowArtifactSpec,
+)
+from odds.policy import DEFAULT_MLB_PITCHER_STRIKEOUT_POLICY, PostablePickLimits
+from pitcher_k.config import PITCHER_K_PROP_MARKET
+from pitcher_k.feature_engineering import build_team_context
+from pitcher_k.feature_tomorrow import build_tomorrow_features
+from pitcher_k.predict import predict_on_dataframe
+
+
+def load_pitcher_history_artifact(path: Path) -> pd.DataFrame:
+    pitcher_games = pd.read_csv(path)
+    pitcher_games["game_date"] = pd.to_datetime(pitcher_games["game_date"])
+    validate_pitcher_games_contract(pitcher_games)
+    return pitcher_games
+
+
+def load_xgboost_model_artifact(path: Path):
+    model = xgb.Booster()
+    model.load_model(str(path))
+    return model
+
+
+def build_mlb_pitcher_strikeout_features(
+    starters_df: pd.DataFrame,
+    pitcher_games: pd.DataFrame,
+) -> pd.DataFrame:
+    as_of_date = starters_df["game_date"].min()
+    team_context = build_team_context(pitcher_games, as_of_date=as_of_date)
+    return build_tomorrow_features(
+        slate_df=starters_df,
+        pitcher_games=pitcher_games,
+        team_context=team_context,
+    )
+
+
+MLB_PITCHER_STRIKEOUT_WORKFLOW = ModelingWorkflowSpec(
+    sport="MLB",
+    participant_key="player_name",
+    market_key=PITCHER_K_PROP_MARKET,
+    artifacts=WorkflowArtifactSpec(
+        history_filename="pitcher_games.csv",
+        history_loader=load_pitcher_history_artifact,
+        model_filename="model.ubj",
+        model_loader=load_xgboost_model_artifact,
+    ),
+    feature_builder=build_mlb_pitcher_strikeout_features,
+    predictor=predict_on_dataframe,
+    projection_odds_join_keys=ProjectionOddsJoinKeys(
+        projection="player_name_norm",
+        odds="player_name_norm",
+    ),
+    pick_ranking_policy=DEFAULT_MLB_PITCHER_STRIKEOUT_POLICY,
+    prediction_columns=(
+        "player_name",
+        "predicted_strikeouts",
+        "lower_bound",
+        "upper_bound",
+        "std_dev",
+    ),
+    postable_limits=PostablePickLimits(
+        max_official=3,
+        max_leans=1,
+    ),
+)

--- a/MLB/tests/jobs/test_run_daily_card.py
+++ b/MLB/tests/jobs/test_run_daily_card.py
@@ -3,7 +3,7 @@ import pytest
 import requests
 
 from jobs import run_daily_card as daily_card
-from common.workflows import ModelingWorkflowSpec, ProjectionOddsJoinKeys
+from common.workflows import ModelingWorkflowSpec, ProjectionOddsJoinKeys, WorkflowArtifactSpec
 from odds.policy import (
     DEFAULT_MLB_PITCHER_STRIKEOUT_POLICY,
     PostablePickLimits,
@@ -92,12 +92,12 @@ def test_run_daily_card_writes_outputs_with_mocked_dependencies(monkeypatch, tmp
     post_df = picks_df.copy()
 
     monkeypatch.setattr(daily_card, "get_today_starters_df", lambda: starters_df)
-    monkeypatch.setattr(daily_card, "load_pitcher_games_artifact", lambda: pitcher_games)
-    monkeypatch.setattr(daily_card, "load_model_artifact", lambda: "fake_model")
+    monkeypatch.setattr(daily_card, "load_workflow_history_artifact", lambda workflow: pitcher_games)
+    monkeypatch.setattr(daily_card, "load_workflow_model_artifact", lambda workflow: "fake_model")
     monkeypatch.setattr(
         daily_card,
         "load_model_metadata",
-        lambda: {"target": "strikeouts", "features": ["pitches_last3"]},
+        lambda workflow=None: {"target": "strikeouts", "features": ["pitches_last3"]},
     )
     monkeypatch.setattr(
         daily_card,
@@ -247,9 +247,9 @@ def test_run_daily_card_allows_explicit_market_and_workflow_behavior(monkeypatch
     post_df = picks_df.copy()
 
     monkeypatch.setattr(daily_card, "get_today_starters_df", lambda: starters_df)
-    monkeypatch.setattr(daily_card, "load_pitcher_games_artifact", lambda: pitcher_games)
-    monkeypatch.setattr(daily_card, "load_model_artifact", lambda: "fake_model")
-    monkeypatch.setattr(daily_card, "load_model_metadata", lambda: {"target": "strikeouts"})
+    monkeypatch.setattr(daily_card, "load_workflow_history_artifact", lambda workflow: pitcher_games)
+    monkeypatch.setattr(daily_card, "load_workflow_model_artifact", lambda workflow: "fake_model")
+    monkeypatch.setattr(daily_card, "load_model_metadata", lambda workflow=None: {"target": "strikeouts"})
     monkeypatch.setattr(
         daily_card,
         "build_today_predictions_for_workflow",
@@ -336,12 +336,12 @@ def test_run_daily_card_raises_when_today_predictions_are_empty(monkeypatch, tmp
     )
 
     monkeypatch.setattr(daily_card, "get_today_starters_df", lambda: starters_df)
-    monkeypatch.setattr(daily_card, "load_pitcher_games_artifact", lambda: pitcher_games)
-    monkeypatch.setattr(daily_card, "load_model_artifact", lambda: "fake_model")
+    monkeypatch.setattr(daily_card, "load_workflow_history_artifact", lambda workflow: pitcher_games)
+    monkeypatch.setattr(daily_card, "load_workflow_model_artifact", lambda workflow: "fake_model")
     monkeypatch.setattr(
         daily_card,
         "load_model_metadata",
-        lambda: {"target": "strikeouts", "features": ["pitches_last3"]},
+        lambda workflow=None: {"target": "strikeouts", "features": ["pitches_last3"]},
     )
     monkeypatch.setattr(
         daily_card,
@@ -387,7 +387,7 @@ def test_run_daily_card_raises_when_pitcher_games_artifact_is_missing(monkeypatc
     def raise_missing_pitcher_games():
         raise FileNotFoundError("Missing pitcher_games artifact: fake/path/pitcher_games.csv")
 
-    monkeypatch.setattr(daily_card, "load_pitcher_games_artifact", raise_missing_pitcher_games)
+    monkeypatch.setattr(daily_card, "load_workflow_history_artifact", raise_missing_pitcher_games)
 
     monkeypatch.setattr(daily_card, "DATA_DIR", tmp_path / "data")
     monkeypatch.setattr(daily_card, "OUTPUT_DIR", tmp_path / "data" / "outputs")
@@ -497,9 +497,9 @@ def test_run_daily_card_uses_workflow_spec_for_market_policy_and_limits(monkeypa
     )
 
     monkeypatch.setattr(daily_card, "get_today_starters_df", lambda: starters_df)
-    monkeypatch.setattr(daily_card, "load_pitcher_games_artifact", lambda: pitcher_games)
-    monkeypatch.setattr(daily_card, "load_model_artifact", lambda: "fake_model")
-    monkeypatch.setattr(daily_card, "load_model_metadata", lambda: {"target": "strikeouts"})
+    monkeypatch.setattr(daily_card, "load_workflow_history_artifact", lambda workflow: pitcher_games)
+    monkeypatch.setattr(daily_card, "load_workflow_model_artifact", lambda workflow: "fake_model")
+    monkeypatch.setattr(daily_card, "load_model_metadata", lambda workflow=None: {"target": "strikeouts"})
     monkeypatch.setattr(
         daily_card,
         "build_today_predictions_for_workflow",
@@ -760,8 +760,8 @@ def test_run_daily_card_handles_live_odds_http_error_gracefully(monkeypatch, tmp
     )
 
     monkeypatch.setattr(daily_card, "get_today_starters_df", lambda: starters_df)
-    monkeypatch.setattr(daily_card, "load_pitcher_games_artifact", lambda: pitcher_games)
-    monkeypatch.setattr(daily_card, "load_model_artifact", lambda: "fake_model")
+    monkeypatch.setattr(daily_card, "load_workflow_history_artifact", lambda workflow: pitcher_games)
+    monkeypatch.setattr(daily_card, "load_workflow_model_artifact", lambda workflow: "fake_model")
     monkeypatch.setattr(daily_card, "load_model_metadata", lambda: {"target": "strikeouts"})
     monkeypatch.setattr(
         daily_card,

--- a/MLB/tests/jobs/test_run_daily_card.py
+++ b/MLB/tests/jobs/test_run_daily_card.py
@@ -384,7 +384,7 @@ def test_run_daily_card_raises_when_pitcher_games_artifact_is_missing(monkeypatc
 
     monkeypatch.setattr(daily_card, "get_today_starters_df", lambda: starters_df)
 
-    def raise_missing_pitcher_games():
+    def raise_missing_pitcher_games(workflow):
         raise FileNotFoundError("Missing pitcher_games artifact: fake/path/pitcher_games.csv")
 
     monkeypatch.setattr(daily_card, "load_workflow_history_artifact", raise_missing_pitcher_games)
@@ -486,6 +486,12 @@ def test_run_daily_card_uses_workflow_spec_for_market_policy_and_limits(monkeypa
         sport="MLB",
         participant_key="player_name",
         market_key="workflow_market",
+        artifacts=WorkflowArtifactSpec(
+            history_filename="history.csv",
+            history_loader=lambda path: pd.DataFrame(),
+            model_filename="model.bin",
+            model_loader=lambda path: "unused-model",
+        ),
         feature_builder=lambda starters, history: starters,
         predictor=lambda model, features: features,
         projection_odds_join_keys=ProjectionOddsJoinKeys(
@@ -493,6 +499,13 @@ def test_run_daily_card_uses_workflow_spec_for_market_policy_and_limits(monkeypa
             odds="player_name_norm",
         ),
         pick_ranking_policy=DEFAULT_MLB_PITCHER_STRIKEOUT_POLICY,
+        prediction_columns=(
+            "player_name",
+            "predicted_strikeouts",
+            "lower_bound",
+            "upper_bound",
+            "std_dev",
+        ),
         postable_limits=PostablePickLimits(max_official=1, max_leans=0),
     )
 
@@ -762,7 +775,7 @@ def test_run_daily_card_handles_live_odds_http_error_gracefully(monkeypatch, tmp
     monkeypatch.setattr(daily_card, "get_today_starters_df", lambda: starters_df)
     monkeypatch.setattr(daily_card, "load_workflow_history_artifact", lambda workflow: pitcher_games)
     monkeypatch.setattr(daily_card, "load_workflow_model_artifact", lambda workflow: "fake_model")
-    monkeypatch.setattr(daily_card, "load_model_metadata", lambda: {"target": "strikeouts"})
+    monkeypatch.setattr(daily_card, "load_model_metadata", lambda workflow=None: {"target": "strikeouts"})
     monkeypatch.setattr(
         daily_card,
         "build_today_predictions_for_workflow",


### PR DESCRIPTION
Summary
This PR removes remaining pitcher-K assumptions from the shared workflow and daily orchestration layers.

What changed
moved MLB pitcher strikeout workflow registration out of common/ and into a pitcher-K owned module
kept common.workflows focused on generic workflow/spec types
added workflow-owned artifact configuration for:
history artifact filename + loader
model artifact filename + loader
metadata filename
updated run_daily_card to load artifacts and validate prediction outputs through the workflow spec instead of hard-coded pitcher-K helpers
moved metadata-based prediction uncertainty adjustment behind the workflow spec as well
Why
The repo already has a first-class workflow spec, but shared orchestration still assumed the original pitcher strikeout pipeline’s storage shape and feature lineage. This change makes adding a second workflow much more registration-driven and avoids editing shared infrastructure for workflow-specific behavior.

Behavior
current MLB pitcher strikeout behavior is preserved
daily card orchestration still resolves artifacts from latest/ then previous/
targeted daily-card tests continue to pass
Testing
& 'C:\ProGramble\proGramble\MLB\.venv\Scripts\python.exe' -m pytest MLB/tests/jobs/test_run_daily_card.py
Closes #26