### PR TITLE
mplemented the profit-tracking mechanism in run_daily_card.py, so eve…

### DIFF
--- a/.github/workflows/daily-mlb-card.yml
+++ b/.github/workflows/daily-mlb-card.yml
@@ -43,18 +43,18 @@ jobs:
         run: |
           python -m jobs.run_daily_card
 
-      - name: Commit official picks history
+      - name: Commit official picks tracking artifacts
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
-          if git diff --quiet -- data/tracking/official_picks_history.csv; then
-            echo "No official picks history changes to commit."
+          if git diff --quiet -- data/tracking/; then
+            echo "No official picks tracking changes to commit."
             exit 0
           fi
 
-          git add data/tracking/official_picks_history.csv
-          git commit -m "Update official picks history"
+          git add data/tracking/
+          git commit -m "Update official picks tracking"
           git push
       
       - name: Notify Discord

--- a/MLB/data/tracking/official_picks_profit_by_book.csv
+++ b/MLB/data/tracking/official_picks_profit_by_book.csv
@@ -1,0 +1,1 @@
+book,picks,wins,losses,pushes,decisions,units_risked,units_profit,win_rate,roi

--- a/MLB/data/tracking/official_picks_profit_report.csv
+++ b/MLB/data/tracking/official_picks_profit_report.csv
@@ -1,0 +1,1 @@
+pick_key,game_date,player_name,team,opponent,book,odds,price,pick_side,line,predicted_strikeouts,edge,confidence_tier,pick_type,result,actual_strikeouts,record_source,result_normalized,odds_numeric,units_risked,units_result

--- a/MLB/data/tracking/official_picks_profit_skipped.csv
+++ b/MLB/data/tracking/official_picks_profit_skipped.csv
@@ -1,0 +1,2 @@
+pick_key,game_date,player_name,team,opponent,book,odds,price,pick_side,line,predicted_strikeouts,edge,confidence_tier,pick_type,result,actual_strikeouts,record_source,result_normalized,odds_numeric,units_risked,units_result
+2026-04-19|jacob degrom,2026-04-19,Jacob deGrom,TEX,SEA,DraftKings,-120,-120,over,5.5,6.8,1.3,medium,official,,,run_daily_card,,-120.0,0.0,

--- a/MLB/data/tracking/official_picks_profit_summary.json
+++ b/MLB/data/tracking/official_picks_profit_summary.json
@@ -1,0 +1,13 @@
+{
+  "books": 0,
+  "picks": 0,
+  "wins": 0,
+  "losses": 0,
+  "pushes": 0,
+  "decisions": 0,
+  "units_risked": 0.0,
+  "units_profit": 0.0,
+  "win_rate": null,
+  "roi": null,
+  "skipped_rows": 1
+}

--- a/MLB/src/jobs/run_daily_card.py
+++ b/MLB/src/jobs/run_daily_card.py
@@ -39,6 +39,10 @@ EDGES_DIR = OUTPUT_DIR / "edges"
 PICKS_DIR = OUTPUT_DIR / "picks"
 RUN_STATUS_PATH = OUTPUT_DIR / "run_daily_card_status.json"
 OFFICIAL_PICKS_HISTORY_PATH = TRACKING_DIR / "official_picks_history.csv"
+OFFICIAL_PICKS_GRADES_PATH = TRACKING_DIR / "official_picks_profit_report.csv"
+OFFICIAL_PICKS_BOOK_SUMMARY_PATH = TRACKING_DIR / "official_picks_profit_by_book.csv"
+OFFICIAL_PICKS_OVERALL_SUMMARY_PATH = TRACKING_DIR / "official_picks_profit_summary.json"
+OFFICIAL_PICKS_SKIPPED_PATH = TRACKING_DIR / "official_picks_profit_skipped.csv"
 
 OFFICIAL_PICKS_HISTORY_COLUMNS = [
     "pick_key",
@@ -58,6 +62,26 @@ OFFICIAL_PICKS_HISTORY_COLUMNS = [
     "result",
     "actual_strikeouts",
     "record_source",
+]
+
+OFFICIAL_PICKS_PROFIT_REPORT_COLUMNS = OFFICIAL_PICKS_HISTORY_COLUMNS + [
+    "result_normalized",
+    "odds_numeric",
+    "units_risked",
+    "units_result",
+]
+
+OFFICIAL_PICKS_PROFIT_SUMMARY_COLUMNS = [
+    "book",
+    "picks",
+    "wins",
+    "losses",
+    "pushes",
+    "decisions",
+    "units_risked",
+    "units_profit",
+    "win_rate",
+    "roi",
 ]
 
 BuildPicksFn = Callable[[pd.DataFrame], pd.DataFrame]
@@ -99,6 +123,207 @@ def _normalize_pick_key_name(player_name: str) -> str:
 
 def _build_pick_key(game_date: str, player_name: str) -> str:
     return f"{game_date}|{_normalize_pick_key_name(player_name)}"
+
+
+def _normalize_pick_result(result: str | None) -> str:
+    normalized = str(result or "").strip().lower()
+    if normalized in {"w", "win"}:
+        return "W"
+    if normalized in {"l", "loss"}:
+        return "L"
+    if normalized == "push":
+        return "Push"
+    return ""
+
+
+def _parse_american_odds(odds: float | int | str | None) -> float | None:
+    if pd.isna(odds):
+        return None
+
+    text = str(odds).strip()
+    if not text:
+        return None
+
+    try:
+        numeric_odds = float(text)
+    except ValueError:
+        return None
+
+    if numeric_odds == 0:
+        return None
+
+    return numeric_odds
+
+
+def _resolve_history_row_odds(row: pd.Series) -> float | None:
+    odds_value = _parse_american_odds(row.get("odds"))
+    if odds_value is not None:
+        return odds_value
+    return _parse_american_odds(row.get("price"))
+
+
+def _profit_units_for_result(odds: float | None, result: str) -> float | None:
+    if result == "Push":
+        return 0.0
+    if result == "L":
+        return -1.0
+    if result != "W" or odds is None:
+        return None
+    if odds > 0:
+        return odds / 100.0
+    return 100.0 / abs(odds)
+
+
+def empty_official_picks_profit_report_df() -> pd.DataFrame:
+    return pd.DataFrame(columns=OFFICIAL_PICKS_PROFIT_REPORT_COLUMNS)
+
+
+def empty_official_picks_profit_summary_df() -> pd.DataFrame:
+    return pd.DataFrame(columns=OFFICIAL_PICKS_PROFIT_SUMMARY_COLUMNS)
+
+
+def summarize_official_picks_profit_by_book(graded_df: pd.DataFrame) -> pd.DataFrame:
+    if graded_df.empty:
+        return empty_official_picks_profit_summary_df()
+
+    summary = (
+        graded_df.groupby("book", dropna=False)
+        .agg(
+            picks=("pick_key", "size"),
+            wins=("result_normalized", lambda s: int((s == "W").sum())),
+            losses=("result_normalized", lambda s: int((s == "L").sum())),
+            pushes=("result_normalized", lambda s: int((s == "Push").sum())),
+            decisions=("units_risked", "sum"),
+            units_risked=("units_risked", "sum"),
+            units_profit=("units_result", "sum"),
+        )
+        .reset_index()
+    )
+    summary["picks"] = summary["picks"].astype(int)
+    summary["wins"] = summary["wins"].astype(int)
+    summary["losses"] = summary["losses"].astype(int)
+    summary["pushes"] = summary["pushes"].astype(int)
+    summary["decisions"] = summary["decisions"].astype(int)
+    summary["win_rate"] = summary.apply(
+        lambda row: row["wins"] / row["decisions"] if row["decisions"] else None,
+        axis=1,
+    )
+    summary["roi"] = summary.apply(
+        lambda row: row["units_profit"] / row["units_risked"] if row["units_risked"] else None,
+        axis=1,
+    )
+    return summary[OFFICIAL_PICKS_PROFIT_SUMMARY_COLUMNS].sort_values(
+        by=["units_profit", "book"],
+        ascending=[False, True],
+    ).reset_index(drop=True)
+
+
+def build_official_picks_profit_report(history_df: pd.DataFrame) -> dict[str, object]:
+    if history_df.empty:
+        return {
+            "graded_df": empty_official_picks_profit_report_df(),
+            "summary_by_book_df": empty_official_picks_profit_summary_df(),
+            "overall_summary": {
+                "books": 0,
+                "picks": 0,
+                "wins": 0,
+                "losses": 0,
+                "pushes": 0,
+                "decisions": 0,
+                "units_risked": 0.0,
+                "units_profit": 0.0,
+                "win_rate": None,
+                "roi": None,
+                "skipped_rows": 0,
+            },
+            "skipped_df": empty_official_picks_profit_report_df(),
+        }
+
+    official_df = history_df[history_df["pick_type"] == "official"].copy()
+    if official_df.empty:
+        return {
+            "graded_df": empty_official_picks_profit_report_df(),
+            "summary_by_book_df": empty_official_picks_profit_summary_df(),
+            "overall_summary": {
+                "books": 0,
+                "picks": 0,
+                "wins": 0,
+                "losses": 0,
+                "pushes": 0,
+                "decisions": 0,
+                "units_risked": 0.0,
+                "units_profit": 0.0,
+                "win_rate": None,
+                "roi": None,
+                "skipped_rows": 0,
+            },
+            "skipped_df": empty_official_picks_profit_report_df(),
+        }
+
+    working = official_df.copy()
+    working["result_normalized"] = working["result"].apply(_normalize_pick_result)
+    working["odds_numeric"] = working.apply(_resolve_history_row_odds, axis=1)
+    working["units_risked"] = 0.0
+    working["units_result"] = pd.NA
+
+    resolved_mask = working["result_normalized"].isin(["W", "L", "Push"])
+    valid_odds_mask = working["odds_numeric"].notna()
+    push_mask = working["result_normalized"] == "Push"
+    gradeable_mask = resolved_mask & (valid_odds_mask | push_mask)
+
+    if gradeable_mask.any():
+        working.loc[gradeable_mask, "units_risked"] = working.loc[
+            gradeable_mask, "result_normalized"
+        ].apply(lambda result: 0.0 if result == "Push" else 1.0)
+        working.loc[gradeable_mask, "units_result"] = working.loc[gradeable_mask].apply(
+            lambda row: _profit_units_for_result(row["odds_numeric"], row["result_normalized"]),
+            axis=1,
+        )
+
+    graded_df = working.loc[gradeable_mask, OFFICIAL_PICKS_PROFIT_REPORT_COLUMNS].copy()
+    skipped_df = working.loc[~gradeable_mask, OFFICIAL_PICKS_PROFIT_REPORT_COLUMNS].copy()
+    summary_by_book_df = summarize_official_picks_profit_by_book(graded_df)
+
+    wins = int((graded_df["result_normalized"] == "W").sum())
+    losses = int((graded_df["result_normalized"] == "L").sum())
+    pushes = int((graded_df["result_normalized"] == "Push").sum())
+    decisions = wins + losses
+    units_risked = float(graded_df["units_risked"].sum()) if not graded_df.empty else 0.0
+    units_profit = float(pd.to_numeric(graded_df["units_result"], errors="coerce").fillna(0.0).sum())
+
+    overall_summary = {
+        "books": int(summary_by_book_df["book"].nunique()) if not summary_by_book_df.empty else 0,
+        "picks": int(len(graded_df)),
+        "wins": wins,
+        "losses": losses,
+        "pushes": pushes,
+        "decisions": decisions,
+        "units_risked": units_risked,
+        "units_profit": units_profit,
+        "win_rate": (wins / decisions) if decisions else None,
+        "roi": (units_profit / units_risked) if units_risked else None,
+        "skipped_rows": int(len(skipped_df)),
+    }
+
+    return {
+        "graded_df": graded_df,
+        "summary_by_book_df": summary_by_book_df,
+        "overall_summary": overall_summary,
+        "skipped_df": skipped_df,
+    }
+
+
+def persist_official_picks_profit_reports() -> dict[str, object]:
+    history_df = load_official_picks_history()
+    report = build_official_picks_profit_report(history_df)
+    report["graded_df"].to_csv(OFFICIAL_PICKS_GRADES_PATH, index=False)
+    report["summary_by_book_df"].to_csv(OFFICIAL_PICKS_BOOK_SUMMARY_PATH, index=False)
+    report["skipped_df"].to_csv(OFFICIAL_PICKS_SKIPPED_PATH, index=False)
+    OFFICIAL_PICKS_OVERALL_SUMMARY_PATH.write_text(
+        json.dumps(report["overall_summary"], indent=2),
+        encoding="utf-8",
+    )
+    return report
 
 
 def load_official_picks_history() -> pd.DataFrame:
@@ -340,6 +565,7 @@ def save_outputs(
     picks_df.to_csv(PICKS_DIR / "today_all_picks.csv", index=False)
     post_df.to_csv(PICKS_DIR / "today_postable_picks.csv", index=False)
     persist_official_picks_history(starters_df, post_df)
+    persist_official_picks_profit_reports()
     save_run_status(status=run_status, message=run_message)
 
 

--- a/MLB/tests/jobs/test_run_daily_card.py
+++ b/MLB/tests/jobs/test_run_daily_card.py
@@ -154,9 +154,18 @@ def test_run_daily_card_writes_outputs_with_mocked_dependencies(monkeypatch, tmp
     assert (daily_card.PICKS_DIR / "today_all_picks.csv").exists()
     assert (daily_card.PICKS_DIR / "today_postable_picks.csv").exists()
     assert daily_card.OFFICIAL_PICKS_HISTORY_PATH.exists()
+    assert daily_card.OFFICIAL_PICKS_GRADES_PATH.exists()
+    assert daily_card.OFFICIAL_PICKS_BOOK_SUMMARY_PATH.exists()
+    assert daily_card.OFFICIAL_PICKS_OVERALL_SUMMARY_PATH.exists()
+    assert daily_card.OFFICIAL_PICKS_SKIPPED_PATH.exists()
 
     loaded_post = pd.read_csv(daily_card.PICKS_DIR / "today_postable_picks.csv")
     loaded_history = pd.read_csv(daily_card.OFFICIAL_PICKS_HISTORY_PATH, keep_default_na=False)
+    loaded_grades = pd.read_csv(daily_card.OFFICIAL_PICKS_GRADES_PATH)
+    loaded_book_summary = pd.read_csv(daily_card.OFFICIAL_PICKS_BOOK_SUMMARY_PATH)
+    loaded_overall = daily_card.json.loads(
+        daily_card.OFFICIAL_PICKS_OVERALL_SUMMARY_PATH.read_text(encoding="utf-8")
+    )
     assert len(loaded_post) == 1
     assert loaded_post.loc[0, "player_name"] == "Jacob deGrom"
     assert loaded_post.loc[0, "pick_type"] == "official"
@@ -164,6 +173,10 @@ def test_run_daily_card_writes_outputs_with_mocked_dependencies(monkeypatch, tmp
     assert loaded_history.loc[0, "game_date"] == "2026-04-19"
     assert str(loaded_history.loc[0, "odds"]) == "-120"
     assert loaded_history.loc[0, "pick_key"] == "2026-04-19|jacob degrom"
+    assert loaded_grades.empty
+    assert loaded_book_summary.empty
+    assert loaded_overall["picks"] == 0
+    assert loaded_overall["skipped_rows"] == 1
 
 
 def test_run_daily_card_allows_explicit_market_and_workflow_behavior(monkeypatch, tmp_path):
@@ -878,3 +891,204 @@ def test_apply_metadata_uncertainty_uses_saved_interval_calibration():
     assert adjusted.loc[0, "std_dev"] == pytest.approx(1.4)
     assert adjusted.loc[0, "lower_bound"] == pytest.approx(5.4)
     assert adjusted.loc[0, "upper_bound"] == pytest.approx(8.2)
+
+
+def test_build_official_picks_profit_report_grades_units_and_aggregates_by_book():
+    history_df = pd.DataFrame(
+        [
+            {
+                "pick_key": "2026-05-01|pitcher a",
+                "game_date": "2026-05-01",
+                "player_name": "Pitcher A",
+                "team": "AAA",
+                "opponent": "BBB",
+                "book": "DraftKings",
+                "odds": "-110",
+                "price": -110,
+                "pick_side": "over",
+                "line": 5.5,
+                "predicted_strikeouts": 6.4,
+                "edge": 0.9,
+                "confidence_tier": "high",
+                "pick_type": "official",
+                "result": "W",
+                "actual_strikeouts": "7",
+                "record_source": "run_daily_card",
+            },
+            {
+                "pick_key": "2026-05-02|pitcher b",
+                "game_date": "2026-05-02",
+                "player_name": "Pitcher B",
+                "team": "CCC",
+                "opponent": "DDD",
+                "book": "FanDuel",
+                "odds": "",
+                "price": 120,
+                "pick_side": "under",
+                "line": 6.5,
+                "predicted_strikeouts": 5.5,
+                "edge": 1.0,
+                "confidence_tier": "high",
+                "pick_type": "official",
+                "result": "L",
+                "actual_strikeouts": "8",
+                "record_source": "run_daily_card",
+            },
+            {
+                "pick_key": "2026-05-03|pitcher c",
+                "game_date": "2026-05-03",
+                "player_name": "Pitcher C",
+                "team": "EEE",
+                "opponent": "FFF",
+                "book": "BetMGM",
+                "odds": "",
+                "price": "",
+                "pick_side": "over",
+                "line": 4.5,
+                "predicted_strikeouts": 5.1,
+                "edge": 0.6,
+                "confidence_tier": "medium",
+                "pick_type": "official",
+                "result": "Push",
+                "actual_strikeouts": "4.5",
+                "record_source": "run_daily_card",
+            },
+            {
+                "pick_key": "2026-05-04|pitcher d",
+                "game_date": "2026-05-04",
+                "player_name": "Pitcher D",
+                "team": "GGG",
+                "opponent": "HHH",
+                "book": "Caesars",
+                "odds": "",
+                "price": "",
+                "pick_side": "over",
+                "line": 4.5,
+                "predicted_strikeouts": 5.1,
+                "edge": 0.6,
+                "confidence_tier": "medium",
+                "pick_type": "official",
+                "result": "W",
+                "actual_strikeouts": "6",
+                "record_source": "run_daily_card",
+            },
+            {
+                "pick_key": "2026-05-05|lean row",
+                "game_date": "2026-05-05",
+                "player_name": "Lean Row",
+                "team": "III",
+                "opponent": "JJJ",
+                "book": "DraftKings",
+                "odds": "+100",
+                "price": 100,
+                "pick_side": "over",
+                "line": 3.5,
+                "predicted_strikeouts": 4.0,
+                "edge": 0.5,
+                "confidence_tier": "medium",
+                "pick_type": "lean",
+                "result": "W",
+                "actual_strikeouts": "5",
+                "record_source": "run_daily_card",
+            },
+        ]
+    )
+
+    report = daily_card.build_official_picks_profit_report(history_df)
+
+    graded_df = report["graded_df"]
+    summary_by_book_df = report["summary_by_book_df"]
+    overall_summary = report["overall_summary"]
+    skipped_df = report["skipped_df"]
+
+    assert len(graded_df) == 3
+    pitcher_a = graded_df.loc[graded_df["player_name"] == "Pitcher A"].iloc[0]
+    pitcher_b = graded_df.loc[graded_df["player_name"] == "Pitcher B"].iloc[0]
+    pitcher_c = graded_df.loc[graded_df["player_name"] == "Pitcher C"].iloc[0]
+    assert pitcher_a["units_result"] == pytest.approx(100 / 110)
+    assert pitcher_a["units_risked"] == pytest.approx(1.0)
+    assert pitcher_b["units_result"] == pytest.approx(-1.0)
+    assert pitcher_b["units_risked"] == pytest.approx(1.0)
+    assert pitcher_c["units_result"] == pytest.approx(0.0)
+    assert pitcher_c["units_risked"] == pytest.approx(0.0)
+
+    by_book = {row["book"]: row for row in summary_by_book_df.to_dict(orient="records")}
+    assert by_book["DraftKings"]["units_profit"] == pytest.approx(100 / 110)
+    assert by_book["FanDuel"]["units_profit"] == pytest.approx(-1.0)
+    assert by_book["BetMGM"]["units_profit"] == pytest.approx(0.0)
+    assert by_book["DraftKings"]["roi"] == pytest.approx(100 / 110)
+    assert by_book["FanDuel"]["roi"] == pytest.approx(-1.0)
+    assert pd.isna(by_book["BetMGM"]["roi"])
+
+    expected_profit = (100 / 110) - 1.0
+    assert overall_summary["picks"] == 3
+    assert overall_summary["wins"] == 1
+    assert overall_summary["losses"] == 1
+    assert overall_summary["pushes"] == 1
+    assert overall_summary["decisions"] == 2
+    assert overall_summary["units_risked"] == pytest.approx(2.0)
+    assert overall_summary["units_profit"] == pytest.approx(expected_profit)
+    assert overall_summary["roi"] == pytest.approx(expected_profit / 2.0)
+    assert overall_summary["skipped_rows"] == 1
+    assert list(skipped_df["player_name"]) == ["Pitcher D"]
+
+
+def test_persist_official_picks_profit_reports_writes_tracking_artifacts(tmp_path, monkeypatch):
+    tracking_dir = tmp_path / "data" / "tracking"
+    tracking_dir.mkdir(parents=True, exist_ok=True)
+    history_path = tracking_dir / "official_picks_history.csv"
+    grades_path = tracking_dir / "official_picks_profit_report.csv"
+    by_book_path = tracking_dir / "official_picks_profit_by_book.csv"
+    summary_path = tracking_dir / "official_picks_profit_summary.json"
+    skipped_path = tracking_dir / "official_picks_profit_skipped.csv"
+
+    history_df = pd.DataFrame(
+        [
+            {
+                "pick_key": "2026-05-01|pitcher a",
+                "game_date": "2026-05-01",
+                "player_name": "Pitcher A",
+                "team": "AAA",
+                "opponent": "BBB",
+                "book": "DraftKings",
+                "odds": "-110",
+                "price": -110,
+                "pick_side": "over",
+                "line": 5.5,
+                "predicted_strikeouts": 6.4,
+                "edge": 0.9,
+                "confidence_tier": "high",
+                "pick_type": "official",
+                "result": "W",
+                "actual_strikeouts": "7",
+                "record_source": "run_daily_card",
+            }
+        ]
+    )
+    history_df.to_csv(history_path, index=False)
+
+    monkeypatch.setattr(daily_card, "TRACKING_DIR", tracking_dir)
+    monkeypatch.setattr(daily_card, "OFFICIAL_PICKS_HISTORY_PATH", history_path)
+    monkeypatch.setattr(daily_card, "OFFICIAL_PICKS_GRADES_PATH", grades_path)
+    monkeypatch.setattr(daily_card, "OFFICIAL_PICKS_BOOK_SUMMARY_PATH", by_book_path)
+    monkeypatch.setattr(daily_card, "OFFICIAL_PICKS_OVERALL_SUMMARY_PATH", summary_path)
+    monkeypatch.setattr(daily_card, "OFFICIAL_PICKS_SKIPPED_PATH", skipped_path)
+
+    daily_card.persist_official_picks_profit_reports()
+
+    assert grades_path.exists()
+    assert by_book_path.exists()
+    assert summary_path.exists()
+    assert skipped_path.exists()
+
+    grades_df = pd.read_csv(grades_path)
+    by_book_df = pd.read_csv(by_book_path)
+    summary_payload = daily_card.json.loads(summary_path.read_text(encoding="utf-8"))
+    skipped_df = pd.read_csv(skipped_path)
+
+    assert grades_df.loc[0, "units_result"] == pytest.approx(100 / 110)
+    assert by_book_df.loc[0, "book"] == "DraftKings"
+    assert by_book_df.loc[0, "units_profit"] == pytest.approx(100 / 110)
+    assert summary_payload["picks"] == 1
+    assert summary_payload["units_profit"] == pytest.approx(100 / 110)
+    assert skipped_df.empty


### PR DESCRIPTION
Implemented the profit-tracking mechanism in run_daily_card.py, so every daily run now rebuilds tracking artifacts from official_picks_history.csv and writes:


official_picks_profit_report.csv: per-pick graded rows with units_result

official_picks_profit_by_book.csv: sportsbook summary

official_picks_profit_summary.json: overall units / ROI summary

official_picks_profit_skipped.csv: official rows skipped because they were pending or had invalid odds
Closes #45 