### PR TITLE
Implemented the historical-lines hygiene follow-up so local raw input…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -151,7 +151,7 @@ MLB/data/artifacts/latest/
 MLB/data/artifacts/previous/
 MLB/data/inputs/starters/today_starters.csv
 MLB/data/outputs/
-MLB/data/raw/historical_lines
+MLB/data/raw/historical_lines/
 # Spyder project settings
 .spyderproject
 .spyproject

--- a/MLB/data/README.md
+++ b/MLB/data/README.md
@@ -2,9 +2,38 @@
 
 This directory intentionally separates committed reference inputs from runtime outputs.
 
-- `raw/` contains checked-in example source data that is useful for notebooks and repeatable local exploration.
+- `raw/` contains source-shaped inputs used for local exploration and job hydration.
+- `raw/historical_lines/` is a local-only import directory for externally hydrated historical market snapshots.
 - `artifacts/latest/`, `artifacts/previous/`, and `artifacts/_staging/` are operational model artifacts produced by jobs and promoted between runs.
 - `inputs/starters/` contains runtime starter slates saved by the daily card job.
 - `outputs/` contains runtime projections, joined edges, and pick exports from daily runs.
 
-Only long-lived example/reference data under `raw/` should be committed by default. Operational artifacts and daily run outputs should be recreated by workflows or local jobs and shared via workflow artifacts when needed.
+## Historical Lines Policy
+
+`raw/historical_lines/` is the landing zone for native historical line snapshot CSVs that contributors populate locally from an external source. Those files are intentionally ignored by Git because they can be large, vendor-derived, or both.
+
+What belongs in `raw/historical_lines/`:
+
+- Raw CSV snapshots shaped like the native historical lines loader expects.
+- Local or externally hydrated files used to build the curated `artifacts/latest/historical_lines.csv` artifact.
+- Temporary developer data needed to reproduce or inspect the historical lines workflow locally.
+
+What should never be committed:
+
+- Bulk historical sportsbook datasets.
+- Vendor-exported raw market archives.
+- Developer-specific local hydrated inputs under `raw/historical_lines/`.
+
+How to populate locally:
+
+1. Place externally hydrated CSV snapshot files in a separate local folder.
+2. Run `python src/jobs/populate_historical_lines_raw.py <path-to-file-or-directory>` from `MLB/`.
+3. Build the curated artifact with `python src/jobs/build_historical_lines_artifact.py`.
+
+The import job copies validated CSVs into `raw/historical_lines/` while preserving subdirectories for directory imports.
+
+## Test And CI Fixtures
+
+CI and unit tests do not depend on any developer-local files under `raw/historical_lines/`. Deterministic fixture inputs live under `tests/fixtures/historical_lines/`, and artifact-oriented tests copy those fixtures into explicit temporary directories before exercising the loader or jobs.
+
+Only small, curated fixture data and reproducible artifacts should be committed by default. Operational artifacts and daily run outputs should be recreated by workflows or local jobs and shared via workflow artifacts when needed.

--- a/MLB/src/jobs/populate_historical_lines_raw.py
+++ b/MLB/src/jobs/populate_historical_lines_raw.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import argparse
+import shutil
+from pathlib import Path
+
+import pandas as pd
+
+from common.contracts import require_columns
+from jobs.build_training_artifacts import RAW_HISTORICAL_LINES_DIR
+from odds.historical_lines import RAW_HISTORICAL_LINES_REQUIRED_COLUMNS
+
+
+def _source_csv_paths(source: Path) -> list[Path]:
+    if not source.exists():
+        raise FileNotFoundError(f"Historical lines source does not exist: {source}")
+
+    if source.is_file():
+        if source.suffix.lower() != ".csv":
+            raise ValueError(f"Historical lines source file must be a CSV: {source}")
+        return [source]
+
+    csv_paths = sorted(path for path in source.rglob("*.csv") if path.is_file())
+    if not csv_paths:
+        raise FileNotFoundError(f"No CSV files found under historical lines source: {source}")
+    return csv_paths
+
+
+def _validate_raw_historical_lines_csv(path: Path) -> None:
+    columns = pd.read_csv(path, nrows=0).columns.tolist()
+    header_df = pd.DataFrame(columns=columns)
+    require_columns(
+        header_df,
+        RAW_HISTORICAL_LINES_REQUIRED_COLUMNS,
+        f"historical_lines_source[{path}]",
+    )
+
+
+def populate_historical_lines_raw(
+    source: Path,
+    *,
+    target: Path = RAW_HISTORICAL_LINES_DIR,
+) -> list[Path]:
+    """
+    Copy externally hydrated raw historical line CSVs into the local raw data tree.
+    """
+    source = source.resolve()
+    target = target.resolve()
+
+    copied_paths: list[Path] = []
+    for csv_path in _source_csv_paths(source):
+        _validate_raw_historical_lines_csv(csv_path)
+        relative_path = csv_path.name if source.is_file() else csv_path.relative_to(source)
+        target_path = target / relative_path
+        target_path.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(csv_path, target_path)
+        copied_paths.append(target_path)
+
+    return copied_paths
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Populate MLB/data/raw/historical_lines/ from a local file or directory "
+            "of externally hydrated CSV snapshots."
+        )
+    )
+    parser.add_argument(
+        "source",
+        type=Path,
+        help="Path to a CSV file or directory containing raw historical lines CSVs.",
+    )
+    parser.add_argument(
+        "--target",
+        type=Path,
+        default=RAW_HISTORICAL_LINES_DIR,
+        help="Destination raw historical lines directory. Defaults to the repo local raw path.",
+    )
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    args = _parse_args()
+    copied = populate_historical_lines_raw(args.source, target=args.target)
+
+    print("Populated raw historical lines directory:")
+    print(f"- source: {args.source.resolve()}")
+    print(f"- target: {args.target.resolve()}")
+    print(f"- copied_csv_files: {len(copied)}")

--- a/MLB/tests/conftest.py
+++ b/MLB/tests/conftest.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+import pytest
+
+
+FIXTURES_DIR = Path(__file__).resolve().parent / "fixtures"
+HISTORICAL_LINES_FIXTURES_DIR = FIXTURES_DIR / "historical_lines"
+
+
+def copy_historical_lines_fixtures(destination: Path) -> list[Path]:
+    copied_paths: list[Path] = []
+    for source_path in sorted(HISTORICAL_LINES_FIXTURES_DIR.rglob("*.csv")):
+        target_path = destination / source_path.relative_to(HISTORICAL_LINES_FIXTURES_DIR)
+        target_path.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(source_path, target_path)
+        copied_paths.append(target_path)
+    return copied_paths
+
+
+@pytest.fixture
+def historical_lines_fixture_dir(tmp_path: Path) -> Path:
+    raw_dir = tmp_path / "raw" / "historical_lines"
+    copy_historical_lines_fixtures(raw_dir)
+    return raw_dir

--- a/MLB/tests/fixtures/historical_lines/2025-08-02/pitcher_strikeouts_sample.csv
+++ b/MLB/tests/fixtures/historical_lines/2025-08-02/pitcher_strikeouts_sample.csv
@@ -1,0 +1,6 @@
+game_date,player_name,market_key,bookmaker,bookmaker_key,side,line,price,event_id,commence_time,pulled_at,snapshot_type,source
+2025-08-02,Jacob deGrom,pitcher_strikeouts,DraftKings,draftkings,Over,6.5,-120,evt_1,2025-08-02T23:10:00Z,2025-08-02T22:00:00Z,raw,fixture
+2025-08-02,Jacob Degrom,pitcher_strikeouts,DraftKings,draftkings,Over,7.0,-110,evt_1,2025-08-02T23:10:00Z,2025-08-02T22:30:00Z,raw,fixture
+2025-08-02,Jacob deGrom,pitcher_strikeouts,DraftKings,draftkings,Over,7.5,100,evt_1,2025-08-02T23:10:00Z,2025-08-02T23:30:00Z,raw,fixture
+2025-08-02,Tarik Skubal,pitcher_strikeouts,FanDuel,fanduel,Under,6.0,105,evt_2,2025-08-02T23:40:00Z,2025-08-02T22:45:00Z,raw,fixture
+2025-08-02,Tarik Skubal,batter_hits,FanDuel,fanduel,Over,1.5,-120,evt_2,2025-08-02T23:40:00Z,2025-08-02T22:45:00Z,raw,fixture

--- a/MLB/tests/jobs/test_build_historical_lines_artifact.py
+++ b/MLB/tests/jobs/test_build_historical_lines_artifact.py
@@ -4,31 +4,14 @@ from jobs import build_historical_lines_artifact as historical_lines_job
 from jobs import build_training_artifacts as training_job
 
 
-def test_build_historical_lines_artifact_writes_native_curated_file(tmp_path, monkeypatch):
-    raw_dir = tmp_path / "data" / "raw" / "historical_lines"
+def test_build_historical_lines_artifact_writes_native_curated_file(
+    tmp_path,
+    monkeypatch,
+    historical_lines_fixture_dir,
+):
+    raw_dir = historical_lines_fixture_dir
     latest_dir = tmp_path / "data" / "artifacts" / "latest"
     previous_dir = tmp_path / "data" / "artifacts" / "previous"
-    raw_dir.mkdir(parents=True, exist_ok=True)
-
-    pd.DataFrame(
-        [
-            {
-                "game_date": "2025-08-02",
-                "player_name": "Jacob deGrom",
-                "market_key": "pitcher_strikeouts",
-                "bookmaker": "DraftKings",
-                "bookmaker_key": "draftkings",
-                "side": "Over",
-                "line": 6.5,
-                "price": -120,
-                "event_id": "evt_1",
-                "commence_time": "2025-08-02T23:10:00Z",
-                "pulled_at": "2025-08-02T22:00:00Z",
-                "snapshot_type": "raw",
-                "source": "fixture",
-            }
-        ]
-    ).to_csv(raw_dir / "sample.csv", index=False)
 
     monkeypatch.setattr(historical_lines_job, "RAW_HISTORICAL_LINES_DIR", raw_dir)
     monkeypatch.setattr(historical_lines_job, "LATEST_DIR", latest_dir)
@@ -40,6 +23,6 @@ def test_build_historical_lines_artifact_writes_native_curated_file(tmp_path, mo
     saved = pd.read_csv(output_path)
 
     assert output_path.exists()
-    assert rows == 1
+    assert rows == 2
     assert saved.loc[0, "player_name_norm"] == "jacob degrom"
     assert saved.loc[0, "selection_rule"] == "latest_pregame_snapshot_per_game_player_book_side"

--- a/MLB/tests/jobs/test_populate_historical_lines_raw.py
+++ b/MLB/tests/jobs/test_populate_historical_lines_raw.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from jobs.populate_historical_lines_raw import populate_historical_lines_raw
+
+
+def test_populate_historical_lines_raw_copies_fixture_tree(
+    tmp_path: Path,
+    historical_lines_fixture_dir: Path,
+):
+    target_dir = tmp_path / "data" / "raw" / "historical_lines"
+
+    copied = populate_historical_lines_raw(historical_lines_fixture_dir, target=target_dir)
+    copied_relative = sorted(path.relative_to(target_dir).as_posix() for path in copied)
+
+    assert copied_relative == ["2025-08-02/pitcher_strikeouts_sample.csv"]
+    populated = pd.read_csv(target_dir / "2025-08-02" / "pitcher_strikeouts_sample.csv")
+    assert set(populated["player_name"]) == {"Jacob deGrom", "Jacob Degrom", "Tarik Skubal"}
+
+
+def test_populate_historical_lines_raw_rejects_missing_required_columns(tmp_path: Path):
+    source_dir = tmp_path / "source"
+    source_dir.mkdir(parents=True, exist_ok=True)
+    pd.DataFrame([{"player_name": "Jacob deGrom"}]).to_csv(source_dir / "bad.csv", index=False)
+
+    with pytest.raises(ValueError, match="missing required columns"):
+        populate_historical_lines_raw(source_dir, target=tmp_path / "target")

--- a/MLB/tests/odds/test_historical_lines.py
+++ b/MLB/tests/odds/test_historical_lines.py
@@ -54,47 +54,13 @@ def test_curate_historical_lines_prefers_latest_pregame_snapshot():
     assert bool(curated.loc[0, "is_closing_line"]) is True
 
 
-def test_build_historical_lines_artifact_df_is_deterministic_with_duplicate_snapshots(tmp_path):
-    raw_dir = tmp_path / "raw" / "historical_lines"
-    raw_dir.mkdir(parents=True, exist_ok=True)
-    raw_df = pd.DataFrame(
-        [
-            {
-                "game_date": "2025-08-02",
-                "player_name": "Jacob deGrom",
-                "market_key": "pitcher_strikeouts",
-                "bookmaker": "DraftKings",
-                "bookmaker_key": "draftkings",
-                "side": "Over",
-                "line": 6.5,
-                "price": -120,
-                "event_id": "evt_1",
-                "commence_time": "2025-08-02T23:10:00Z",
-                "pulled_at": "2025-08-02T22:00:00Z",
-                "snapshot_type": "raw",
-                "source": "fixture",
-            },
-            {
-                "game_date": "2025-08-02",
-                "player_name": "Jacob Degrom",
-                "market_key": "pitcher_strikeouts",
-                "bookmaker": "DraftKings",
-                "bookmaker_key": "draftkings",
-                "side": "Over",
-                "line": 7.0,
-                "price": -110,
-                "event_id": "evt_1",
-                "commence_time": "2025-08-02T23:10:00Z",
-                "pulled_at": "2025-08-02T22:30:00Z",
-                "snapshot_type": "raw",
-                "source": "fixture",
-            },
-        ]
-    )
-    raw_df.to_csv(raw_dir / "pitcher_strikeouts_sample.csv", index=False)
+def test_build_historical_lines_artifact_df_is_deterministic_with_fixture_input(
+    historical_lines_fixture_dir,
+):
+    curated = build_historical_lines_artifact_df(historical_lines_fixture_dir)
 
-    curated = build_historical_lines_artifact_df(raw_dir)
-
-    assert len(curated) == 1
+    assert len(curated) == 2
     assert curated.loc[0, "player_name_norm"] == "jacob degrom"
     assert curated.loc[0, "line"] == pytest.approx(7.0)
+    assert curated.loc[1, "player_name_norm"] == "tarik skubal"
+    assert curated.loc[1, "market_key"] == "pitcher_strikeouts"


### PR DESCRIPTION
…s stay out of Git and tests stay deterministic.I added an explicit ignore boundary for MLB/data/raw/historical_lines/ in .gitignore, introduced a checked-in fixture tree plus shared test fixture wiring in MLB/tests/conftest.py and MLB/tests/fixtures/historical_lines/2025-08-02/pitcher_strikeouts_sample.csv, and updated the artifact-focused tests to copy fixture data into explicit temp dirs instead of ever relying on developer-local raw files in MLB/tests/odds/test_historical_lines.py and MLB/tests/jobs/test_build_historical_lines_artifact.py.

For local hydration, I added MLB/src/jobs/populate_historical_lines_raw.py, which validates required columns and copies externally hydrated CSVs into the local raw tree, plus coverage in MLB/tests/jobs/test_populate_historical_lines_raw.py. I also expanded MLB/data/README.md to document what belongs in raw/historical_lines/, what must never be committed, how to populate it locally, and which fixture data CI/tests use.

Verified with:

powershell