### PR TITLE
Feature/prev w l

### DIFF
--- a/MLB/data/tracking/official_picks_history.csv
+++ b/MLB/data/tracking/official_picks_history.csv
@@ -48,9 +48,9 @@ legacy-0031,,Yusei Kikuchi,,,BetMGM,115,115,under,5.5,,,,official,W,,manual_seed
 2026-05-05|peter lambert,2026-05-05,Peter Lambert,HOU,LAD,BetMGM,115,115,under,4.5,2.7774240970611572,1.7225759029388428,high,official,W,,run_daily_card
 2026-05-05|stephen kolek,2026-05-05,Stephen Kolek,KC,CLE,DraftKings,-157,-157,over,2.5,4.562065601348877,2.062065601348877,high,official,W,,run_daily_card
 2026-05-05|shohei ohtani,2026-05-05,Shohei Ohtani,LAD,HOU,DraftKings,-152,-152,under,7.5,5.5092058181762695,1.9907941818237305,high,official,L,,run_daily_card
-2026-05-06|sonny gray,2026-05-06,Sonny Gray,BOS,DET,DraftKings,108,108,over,4.5,6.3377814292907715,1.8377814292907715,high,official,,,run_daily_card
-2026-05-06|bryan woo,2026-05-06,Bryan Woo,SEA,ATL,BetMGM,-160,-160,over,4.5,6.964148044586182,2.4641480445861816,high,official,,,run_daily_card
-2026-05-06|adrian houser,2026-05-06,Adrian Houser,SF,SD,FanDuel,120,120,over,3.5,4.868718147277832,1.368718147277832,high,official,,,run_daily_card
+2026-05-06|sonny gray,2026-05-06,Sonny Gray,BOS,DET,DraftKings,108,108,over,4.5,6.3377814292907715,1.8377814292907715,high,official,L,,run_daily_card
+2026-05-06|bryan woo,2026-05-06,Bryan Woo,SEA,ATL,BetMGM,-160,-160,over,4.5,6.964148044586182,2.4641480445861816,high,official,W,,run_daily_card
+2026-05-06|adrian houser,2026-05-06,Adrian Houser,SF,SD,FanDuel,120,120,over,3.5,4.868718147277832,1.368718147277832,high,official,L,,run_daily_card
 2026-05-07|simeon woods richardson,2026-05-07,Simeon Woods Richardson,MIN,WSH,FanDuel,-118,-118,over,3.5,5.686676502227783,2.186676502227783,high,official,,,run_daily_card
 2026-05-07|zac gallen,2026-05-07,Zac Gallen,AZ,PIT,DraftKings,-119,-119,over,4.5,6.00658655166626,1.5065865516662598,high,official,,,run_daily_card
 2026-05-07|jt ginn,2026-05-07,JT Ginn,ATH,PHI,FanDuel,+110,110,over,4.5,5.752137184143066,1.2521371841430664,high,official,,,run_daily_card

--- a/MLB/src/jobs/run_daily_card.py
+++ b/MLB/src/jobs/run_daily_card.py
@@ -35,6 +35,9 @@ from common.identity import (
 )
 from common.workflows import ModelingWorkflowSpec
 from pitcher_k.workflow import MLB_PITCHER_STRIKEOUT_WORKFLOW
+from pitcher_k.data_loader import load_statcast_data
+from pitcher_k.feature_engineering import build_pitcher_game_table
+from pitcher_k.preprocessing import add_outcome_flags
 
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
 DATA_DIR = PROJECT_ROOT / "data"
@@ -201,6 +204,186 @@ def _profit_units_for_result(odds: float | None, result: str) -> float | None:
     if odds > 0:
         return odds / 100.0
     return 100.0 / abs(odds)
+
+
+def _yesterday_game_date() -> str:
+    return (
+        pd.Timestamp.now(tz="America/New_York").normalize() - pd.Timedelta(days=1)
+    ).strftime("%Y-%m-%d")
+
+
+def _is_pitcher_strikeout_history_row(row: pd.Series) -> bool:
+    market_key = str(row.get("market_key", "") or "").strip()
+    return market_key in {"", "pitcher_strikeouts"}
+
+
+def _grade_pick_result_from_actual(actual: float, line: float, pick_side: str) -> str:
+    pick_side_norm = str(pick_side or "").strip().lower()
+    if pick_side_norm == "over":
+        if actual > line:
+            return "W"
+        if actual < line:
+            return "L"
+        return "Push"
+
+    if pick_side_norm == "under":
+        if actual < line:
+            return "W"
+        if actual > line:
+            return "L"
+        return "Push"
+
+    return ""
+
+
+def _format_stat_value(value: float | int) -> str:
+    return f"{float(value):g}"
+
+
+def load_pitcher_results_from_statcast(game_date: str) -> pd.DataFrame:
+    sc = load_statcast_data(game_date, game_date, chunk_days=1)
+    if sc.empty:
+        return pd.DataFrame(
+            columns=[
+                "game_date",
+                "pitcher",
+                "player_name",
+                "strikeouts",
+            ]
+        )
+
+    sc = add_outcome_flags(sc)
+    pitcher_games = build_pitcher_game_table(sc)
+    pitcher_games["game_date"] = pd.to_datetime(pitcher_games["game_date"]).dt.strftime("%Y-%m-%d")
+    pitcher_games = ensure_participant_identity(
+        pitcher_games,
+        display_name_col="player_name",
+        source_id_col="pitcher",
+        source_id_type="mlbam_player",
+    )
+    return pitcher_games
+
+
+def apply_statcast_results_to_official_picks_history(
+    history_df: pd.DataFrame,
+    pitcher_results_df: pd.DataFrame,
+    *,
+    game_date: str,
+) -> pd.DataFrame:
+    if history_df.empty:
+        return history_df.copy()
+
+    working = history_df.copy()
+    for column in OFFICIAL_PICKS_HISTORY_COLUMNS:
+        if column not in working.columns:
+            working[column] = ""
+
+    working = ensure_participant_identity(
+        working,
+        display_name_col="player_name",
+        normalized_name_col=PARTICIPANT_NAME_NORM_COLUMN,
+        source_id_col=PARTICIPANT_SOURCE_ID_COLUMN,
+        source_id_type="mlbam_player",
+    )
+
+    if pitcher_results_df.empty:
+        return working[OFFICIAL_PICKS_HISTORY_COLUMNS].copy()
+
+    pitcher_results = pitcher_results_df.copy()
+    pitcher_results = ensure_participant_identity(
+        pitcher_results,
+        display_name_col="player_name",
+        source_id_col="pitcher" if "pitcher" in pitcher_results.columns else PARTICIPANT_SOURCE_ID_COLUMN,
+        source_id_type="mlbam_player",
+    )
+
+    result_lookup = pitcher_results.drop_duplicates(
+        subset=["game_date", PARTICIPANT_JOIN_KEY_COLUMN],
+        keep="last",
+    )[
+        ["game_date", PARTICIPANT_JOIN_KEY_COLUMN, "strikeouts"]
+    ].copy()
+
+    pending_mask = (
+        (working["pick_type"] == "official")
+        & (working["game_date"].astype(str) == game_date)
+        & working.apply(_is_pitcher_strikeout_history_row, axis=1)
+        & (
+            working["actual_strikeouts"].astype(str).str.strip().eq("")
+            | working["result"].astype(str).str.strip().eq("")
+        )
+    )
+    if not pending_mask.any():
+        return working[OFFICIAL_PICKS_HISTORY_COLUMNS].copy()
+
+    pending = working.loc[pending_mask].copy()
+    pending["history_row_index"] = pending.index
+    pending = pending.merge(
+        result_lookup,
+        on=["game_date", PARTICIPANT_JOIN_KEY_COLUMN],
+        how="left",
+    )
+    resolved_mask = pending["strikeouts"].notna()
+    if not resolved_mask.any():
+        return working[OFFICIAL_PICKS_HISTORY_COLUMNS].copy()
+
+    pending.loc[resolved_mask, "actual_strikeouts"] = pending.loc[resolved_mask, "strikeouts"].apply(
+        _format_stat_value
+    )
+    pending.loc[resolved_mask, "result"] = pending.loc[resolved_mask].apply(
+        lambda row: _grade_pick_result_from_actual(
+            actual=float(row["strikeouts"]),
+            line=float(row["line"]),
+            pick_side=str(row["pick_side"]),
+        ),
+        axis=1,
+    )
+
+    working.loc[pending["history_row_index"], OFFICIAL_PICKS_HISTORY_COLUMNS] = pending[
+        OFFICIAL_PICKS_HISTORY_COLUMNS
+    ].values
+    return working[OFFICIAL_PICKS_HISTORY_COLUMNS].copy()
+
+
+def grade_official_picks_from_statcast(
+    *,
+    game_date: str | None = None,
+) -> dict[str, object]:
+    target_date = game_date or _yesterday_game_date()
+    history_df = load_official_picks_history()
+    if history_df.empty:
+        persist_official_picks_profit_reports()
+        return {"game_date": target_date, "updated_rows": 0, "history_df": history_df}
+
+    pending_mask = (
+        (history_df["pick_type"] == "official")
+        & (history_df["game_date"].astype(str) == target_date)
+        & history_df.apply(_is_pitcher_strikeout_history_row, axis=1)
+        & (
+            history_df["actual_strikeouts"].astype(str).str.strip().eq("")
+            | history_df["result"].astype(str).str.strip().eq("")
+        )
+    )
+    if not pending_mask.any():
+        persist_official_picks_profit_reports()
+        return {"game_date": target_date, "updated_rows": 0, "history_df": history_df}
+
+    pitcher_results_df = load_pitcher_results_from_statcast(target_date)
+    updated_history_df = apply_statcast_results_to_official_picks_history(
+        history_df,
+        pitcher_results_df,
+        game_date=target_date,
+    )
+    before = history_df["actual_strikeouts"].astype(str).str.strip()
+    after = updated_history_df["actual_strikeouts"].astype(str).str.strip()
+    updated_rows = int(((before == "") & (after != "")).sum())
+    updated_history_df.to_csv(OFFICIAL_PICKS_HISTORY_PATH, index=False)
+    persist_official_picks_profit_reports()
+    return {
+        "game_date": target_date,
+        "updated_rows": updated_rows,
+        "history_df": updated_history_df,
+    }
 
 
 def empty_official_picks_profit_report_df() -> pd.DataFrame:
@@ -630,7 +813,14 @@ def save_outputs(
     picks_df.to_csv(PICKS_DIR / "today_all_picks.csv", index=False)
     post_df.to_csv(PICKS_DIR / "today_postable_picks.csv", index=False)
     persist_official_picks_history(starters_df, post_df)
-    persist_official_picks_profit_reports()
+    try:
+        grade_official_picks_from_statcast()
+    except Exception as exc:
+        print(
+            "WARNING: Failed to grade official picks from Statcast for "
+            f"{_yesterday_game_date()}: {exc.__class__.__name__}: {exc}"
+        )
+        persist_official_picks_profit_reports()
     save_run_status(status=run_status, message=run_message)
 
 

--- a/MLB/tests/jobs/test_run_daily_card.py
+++ b/MLB/tests/jobs/test_run_daily_card.py
@@ -128,6 +128,26 @@ def test_run_daily_card_writes_outputs_with_mocked_dependencies(monkeypatch, tmp
         "OFFICIAL_PICKS_HISTORY_PATH",
         tmp_path / "data" / "tracking" / "official_picks_history.csv",
     )
+    monkeypatch.setattr(
+        daily_card,
+        "OFFICIAL_PICKS_GRADES_PATH",
+        tmp_path / "data" / "tracking" / "official_picks_profit_report.csv",
+    )
+    monkeypatch.setattr(
+        daily_card,
+        "OFFICIAL_PICKS_BOOK_SUMMARY_PATH",
+        tmp_path / "data" / "tracking" / "official_picks_profit_by_book.csv",
+    )
+    monkeypatch.setattr(
+        daily_card,
+        "OFFICIAL_PICKS_OVERALL_SUMMARY_PATH",
+        tmp_path / "data" / "tracking" / "official_picks_profit_summary.json",
+    )
+    monkeypatch.setattr(
+        daily_card,
+        "OFFICIAL_PICKS_SKIPPED_PATH",
+        tmp_path / "data" / "tracking" / "official_picks_profit_skipped.csv",
+    )
 
     saved_starters = {}
 
@@ -1151,3 +1171,139 @@ def test_persist_official_picks_profit_reports_writes_tracking_artifacts(tmp_pat
     assert summary_payload["picks"] == 1
     assert summary_payload["units_profit"] == pytest.approx(100 / 110)
     assert skipped_df.empty
+
+
+def test_apply_statcast_results_to_official_picks_history_updates_yesterday_pick_results():
+    history_df = pd.DataFrame(
+        [
+            {
+                "pick_key": "2026-05-06|pitcher-a",
+                "game_date": "2026-05-06",
+                "player_name": "Pitcher A",
+                "participant_join_key": "mlbam_player:101",
+                "participant_id": "mlbam_player:101",
+                "participant_source_id": "101",
+                "participant_source_id_type": "mlbam_player",
+                "participant_name_norm": "pitcher a",
+                "sport": "MLB",
+                "market_key": "pitcher_strikeouts",
+                "market_family": "player_prop",
+                "team": "AAA",
+                "opponent": "BBB",
+                "book": "DraftKings",
+                "bookmaker_key": "draftkings",
+                "event_id": "evt_1",
+                "odds": "-110",
+                "price": -110,
+                "pick_side": "over",
+                "line": 5.5,
+                "market_selection_key": "MLB|pitcher_strikeouts|mlbam_player:101|over|5.5",
+                "market_offer_key": "MLB|pitcher_strikeouts|mlbam_player:101|over|5.5|draftkings",
+                "predicted_strikeouts": 6.2,
+                "edge": 0.7,
+                "confidence_tier": "high",
+                "pick_type": "official",
+                "result": "",
+                "actual_strikeouts": "",
+                "record_source": "run_daily_card",
+            }
+        ]
+    )
+    pitcher_results_df = pd.DataFrame(
+        [
+            {
+                "game_date": "2026-05-06",
+                "pitcher": 101,
+                "player_name": "Pitcher A",
+                "strikeouts": 6,
+            }
+        ]
+    )
+
+    updated = daily_card.apply_statcast_results_to_official_picks_history(
+        history_df,
+        pitcher_results_df,
+        game_date="2026-05-06",
+    )
+
+    assert updated.loc[0, "actual_strikeouts"] == "6"
+    assert updated.loc[0, "result"] == "W"
+
+
+def test_grade_official_picks_from_statcast_persists_updates_and_profit_reports(tmp_path, monkeypatch):
+    tracking_dir = tmp_path / "data" / "tracking"
+    tracking_dir.mkdir(parents=True, exist_ok=True)
+    history_path = tracking_dir / "official_picks_history.csv"
+    grades_path = tracking_dir / "official_picks_profit_report.csv"
+    by_book_path = tracking_dir / "official_picks_profit_by_book.csv"
+    summary_path = tracking_dir / "official_picks_profit_summary.json"
+    skipped_path = tracking_dir / "official_picks_profit_skipped.csv"
+
+    history_df = pd.DataFrame(
+        [
+            {
+                "pick_key": "2026-05-06|pitcher-a",
+                "game_date": "2026-05-06",
+                "player_name": "Pitcher A",
+                "participant_join_key": "mlbam_player:101",
+                "participant_id": "mlbam_player:101",
+                "participant_source_id": "101",
+                "participant_source_id_type": "mlbam_player",
+                "participant_name_norm": "pitcher a",
+                "sport": "MLB",
+                "market_key": "pitcher_strikeouts",
+                "market_family": "player_prop",
+                "team": "AAA",
+                "opponent": "BBB",
+                "book": "DraftKings",
+                "bookmaker_key": "draftkings",
+                "event_id": "evt_1",
+                "odds": "-110",
+                "price": -110,
+                "pick_side": "under",
+                "line": 5.5,
+                "market_selection_key": "MLB|pitcher_strikeouts|mlbam_player:101|under|5.5",
+                "market_offer_key": "MLB|pitcher_strikeouts|mlbam_player:101|under|5.5|draftkings",
+                "predicted_strikeouts": 4.7,
+                "edge": 0.8,
+                "confidence_tier": "high",
+                "pick_type": "official",
+                "result": "",
+                "actual_strikeouts": "",
+                "record_source": "run_daily_card",
+            }
+        ]
+    )
+    history_df.to_csv(history_path, index=False)
+
+    monkeypatch.setattr(daily_card, "OFFICIAL_PICKS_HISTORY_PATH", history_path)
+    monkeypatch.setattr(daily_card, "OFFICIAL_PICKS_GRADES_PATH", grades_path)
+    monkeypatch.setattr(daily_card, "OFFICIAL_PICKS_BOOK_SUMMARY_PATH", by_book_path)
+    monkeypatch.setattr(daily_card, "OFFICIAL_PICKS_OVERALL_SUMMARY_PATH", summary_path)
+    monkeypatch.setattr(daily_card, "OFFICIAL_PICKS_SKIPPED_PATH", skipped_path)
+    monkeypatch.setattr(
+        daily_card,
+        "load_pitcher_results_from_statcast",
+        lambda game_date: pd.DataFrame(
+            [
+                {
+                    "game_date": game_date,
+                    "pitcher": 101,
+                    "player_name": "Pitcher A",
+                    "strikeouts": 7,
+                }
+            ]
+        ),
+    )
+
+    result = daily_card.grade_official_picks_from_statcast(game_date="2026-05-06")
+
+    loaded_history = pd.read_csv(history_path, keep_default_na=False)
+    grades_df = pd.read_csv(grades_path)
+    summary_payload = daily_card.json.loads(summary_path.read_text(encoding="utf-8"))
+
+    assert result["updated_rows"] == 1
+    assert str(loaded_history.loc[0, "actual_strikeouts"]) == "7"
+    assert loaded_history.loc[0, "result"] == "L"
+    assert grades_df.loc[0, "result"] == "L"
+    assert summary_payload["losses"] == 1


### PR DESCRIPTION
Closes #37 
Added the missing grading workflow in run_daily_card.py. It now:

Looks for unresolved official picks from yesterday in America/New_York.
Pulls that one-day Statcast slice.
Aggregates pitcher strikeout totals.
Backfills actual_strikeouts and result (W, L, Push) in official_picks_history.csv.
Rebuilds the profit-report artifacts from the updated history.

The grading logic prefers canonical participant identity and falls back cleanly for older history rows, so it can match by MLBAM pitcher id when present and by normalized participant identity otherwise. I also made the daily save flow keep generating the tracking report files even when there’s nothing new to grade.

Tests were added in test_run_daily_card.py for both the pure history-update path and the full persisted grading flow. Verification: pytest tests\odds\test_normalize.py tests\odds\test_compare.py tests\odds\test_create_picks.py tests\odds\test_backtest.py tests\odds\test_historical_lines.py tests\jobs\test_run_daily_card.py with 52 passing tests.