### PR TITLE
added the pitcher_bb scaffold

### DIFF
--- a/MLB/docs/supported_props.md
+++ b/MLB/docs/supported_props.md
@@ -1,0 +1,21 @@
+# Supported MLB Props
+
+## Fully Wired Today
+
+- `pitcher_strikeouts`
+  - training artifacts
+  - daily projections
+  - live odds join
+  - picks / postable picks
+  - historical line artifact support
+  - grading and tracking
+
+## Scaffolded For Future Workflow Expansion
+
+- `pitcher_walks`
+  - configuration scaffold exists in [src/pitcher_bb/config.py](../src/pitcher_bb/config.py)
+  - market key: `pitcher_walks`
+  - target column: `walks`
+  - initial base features are defined from shared pitcher workload/context columns
+
+`pitcher_walks` is not yet a full workflow. The current training job, prediction workflow, and grading path remain strikeout-specific, so adding only the config/package is the correct implementation at this stage.

--- a/MLB/src/pitcher_bb/README.md
+++ b/MLB/src/pitcher_bb/README.md
@@ -1,0 +1,18 @@
+# Pitcher Walks Scaffold
+
+This package defines the initial market and model configuration scaffold for MLB pitcher walks props.
+
+Current support level:
+
+- `pitcher_walks` market key is reserved in code via `PITCHER_BB_PROP_MARKET`.
+- `TARGET_COL` is defined as `walks`.
+- `BASE_FEATURES` is intentionally conservative and limited to shared pitcher workload/context columns that already exist in the current feature pipeline.
+
+Not wired yet:
+
+- walk-specific feature engineering
+- pitcher-walks training workflow and artifacts
+- pitcher-walks daily-card workflow
+- grading logic for pitcher-walk outcomes
+
+This keeps the module truthful to the current repo shape while giving the project a stable place to grow the pitcher-walk workflow next.

--- a/MLB/src/pitcher_bb/config.py
+++ b/MLB/src/pitcher_bb/config.py
@@ -1,0 +1,32 @@
+RAW_STATCAST_START = "2023-03-27"
+RAW_STATCAST_END = "2025-09-30"
+TRAIN_SPLIT_DATE = "2025-08-01"
+PITCHER_BB_PROP_MARKET = "pitcher_walks"
+STARTER_LIKE_MIN_PITCHES = 40
+STARTER_LIKE_MIN_BATTERS_FACED = 12
+
+# Walk-specific rolling features are not engineered in the current shared
+# pipeline yet, so start with stable workload/context columns that already
+# exist in the pitcher feature set.
+BASE_FEATURES = [
+    "pitches_last3",
+    "pitches_last10",
+    "batters_faced_last3",
+    "batters_faced_last10",
+    "avg_velo_last3",
+    "avg_spin_last3",
+    "opp_strikeouts_per_game_last10",
+    "opp_k_rate_last10",
+]
+
+TARGET_COL = "walks"
+
+XGB_PARAMS = {
+    "objective": "reg:squarederror",
+    "max_depth": 4,
+    "eta": 0.05,
+    "subsample": 0.8,
+    "colsample_bytree": 0.8,
+    "seed": 42,
+    "eval_metric": "mae",
+}

--- a/MLB/tests/pitcher_bb/test_config.py
+++ b/MLB/tests/pitcher_bb/test_config.py
@@ -1,0 +1,12 @@
+from pitcher_bb.config import BASE_FEATURES, PITCHER_BB_PROP_MARKET, TARGET_COL
+
+
+def test_pitcher_bb_config_defines_expected_market_and_target():
+    assert PITCHER_BB_PROP_MARKET == "pitcher_walks"
+    assert TARGET_COL == "walks"
+
+
+def test_pitcher_bb_config_starts_with_non_empty_base_features():
+    assert BASE_FEATURES
+    assert "pitches_last3" in BASE_FEATURES
+    assert "batters_faced_last10" in BASE_FEATURES


### PR DESCRIPTION

I added the pitcher_bb scaffold in config.py with PITCHER_BB_PROP_MARKET = "pitcher_walks", TARGET_COL = "walks", and an initial BASE_FEATURES list. I did not wire it into run_daily_card or training jobs yet, because the current workflow is still strikeout-specific end to end: the existing feature engineering does not produce walk-specific rolling features, and the training/prediction/grading paths are all built around strikeouts. Treating this as a scaffold is the correct fit for the repo as it stands.

I also documented that support level in supported_props.md and added a package note in README.md, so we’re explicit that pitcher_walks is configured but not yet a fully wired workflow. To keep this from regressing silently, I added test_config.py covering the market key, target, and non-empty base feature list.

Verification: pytest tests/pitcher_bb/test_config.py tests/pitcher_k/test_feature_model.py passed with 4 passed.

Closes #39 