### PR TITLE
The current pitcher_bb scaffold was the right starting point, but the…

### DIFF
--- a/MLB/docs/supported_props.md
+++ b/MLB/docs/supported_props.md
@@ -10,12 +10,13 @@
   - historical line artifact support
   - grading and tracking
 
-## Scaffolded For Future Workflow Expansion
+## Partially Wired
 
 - `pitcher_walks`
-  - configuration scaffold exists in [src/pitcher_bb/config.py](../src/pitcher_bb/config.py)
+  - configuration exists in [src/pitcher_bb/config.py](../src/pitcher_bb/config.py)
   - market key: `pitcher_walks`
   - target column: `walks`
-  - initial base features are defined from shared pitcher workload/context columns
+  - training artifact workflow exists for pitcher-walk models
+  - initial base features are defined from shared pitcher workload/context columns plus walk-specific rolling features
 
-`pitcher_walks` is not yet a full workflow. The current training job, prediction workflow, and grading path remain strikeout-specific, so adding only the config/package is the correct implementation at this stage.
+`pitcher_walks` is not yet a full live-picks workflow. Training artifacts now have a dedicated module and artifact directory, but daily projections, live odds picks, and grading remain strikeout-specific.

--- a/MLB/src/jobs/build_training_artifacts_pitcher_bb.py
+++ b/MLB/src/jobs/build_training_artifacts_pitcher_bb.py
@@ -1,0 +1,309 @@
+from __future__ import annotations
+
+import json
+import shutil
+from pathlib import Path
+
+import pandas as pd
+
+from common.contracts import require_columns, validate_pitcher_games_contract
+from odds.historical_lines import build_historical_lines_artifact_df
+from pitcher_bb.config import (
+    BASE_FEATURES,
+    PITCHER_BB_PROP_MARKET,
+    RAW_STATCAST_END,
+    RAW_STATCAST_START,
+    TARGET_COL,
+    TRAIN_SPLIT_DATE,
+    XGB_PARAMS,
+)
+from pitcher_bb.feature_engineering import (
+    build_pitcher_walk_feature_table,
+    filter_starter_like_appearances,
+)
+from pitcher_bb.feature_model import build_model_df
+from pitcher_bb.train import time_split, train_model
+from pitcher_k.data_loader import load_statcast_data
+from pitcher_k.evaluate import evaluate_predictions, fit_interval_calibration, summarize_interval_coverage
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+DATA_DIR = PROJECT_ROOT / "data"
+ARTIFACTS_DIR = DATA_DIR / "artifacts" / "pitcher_bb"
+STAGING_DIR = ARTIFACTS_DIR / "_staging"
+LATEST_DIR = ARTIFACTS_DIR / "latest"
+PREVIOUS_DIR = ARTIFACTS_DIR / "previous"
+MODEL_FILENAME = "model.ubj"
+PITCHER_GAMES_FILENAME = "pitcher_games.csv"
+MODEL_DF_FILENAME = "model_df.csv"
+HISTORICAL_LINES_FILENAME = "historical_lines.csv"
+METADATA_FILENAME = "metadata.json"
+RAW_HISTORICAL_LINES_DIR = DATA_DIR / "raw" / "historical_lines"
+UNCERTAINTY_STDDEV_COLUMN = "walks_stddev_last10"
+
+
+def ensure_artifact_dirs() -> None:
+    ARTIFACTS_DIR.mkdir(parents=True, exist_ok=True)
+    LATEST_DIR.mkdir(parents=True, exist_ok=True)
+    PREVIOUS_DIR.mkdir(parents=True, exist_ok=True)
+
+
+def artifact_paths(base_dir: Path) -> dict[str, Path]:
+    return {
+        "model": base_dir / MODEL_FILENAME,
+        "pitcher_games": base_dir / PITCHER_GAMES_FILENAME,
+        "model_df": base_dir / MODEL_DF_FILENAME,
+        "historical_lines": base_dir / HISTORICAL_LINES_FILENAME,
+        "metadata": base_dir / METADATA_FILENAME,
+    }
+
+
+def artifact_set_exists(base_dir: Path) -> bool:
+    return all(path.exists() for path in artifact_paths(base_dir).values())
+
+
+def copy_artifact_dir(src: Path, dst: Path) -> None:
+    if dst.exists():
+        shutil.rmtree(dst)
+    shutil.copytree(src, dst)
+
+
+def promote_latest_to_previous() -> None:
+    if artifact_set_exists(LATEST_DIR):
+        copy_artifact_dir(LATEST_DIR, PREVIOUS_DIR)
+
+
+def promote_staging_to_latest() -> None:
+    copy_artifact_dir(STAGING_DIR, LATEST_DIR)
+
+
+def build_historical_pitcher_games() -> pd.DataFrame:
+    sc = load_statcast_data(RAW_STATCAST_START, RAW_STATCAST_END)
+    pitcher_games = build_pitcher_walk_feature_table(sc)
+
+    validate_pitcher_games_contract(pitcher_games)
+    require_columns(pitcher_games, BASE_FEATURES + [TARGET_COL], "pitcher_games")
+    return pitcher_games
+
+
+def build_native_historical_lines() -> pd.DataFrame:
+    return build_historical_lines_artifact_df(
+        RAW_HISTORICAL_LINES_DIR,
+        market_key=PITCHER_BB_PROP_MARKET,
+    )
+
+
+def _date_range(df: pd.DataFrame) -> dict[str, str | None]:
+    if df.empty:
+        return {"start": None, "end": None}
+
+    game_dates = pd.to_datetime(df["game_date"])
+    return {
+        "start": game_dates.min().strftime("%Y-%m-%d"),
+        "end": game_dates.max().strftime("%Y-%m-%d"),
+    }
+
+
+def _build_prediction_results(X_test: pd.DataFrame, y_test, y_pred) -> pd.DataFrame:
+    results = X_test.copy()
+    results["actual_walks"] = pd.Series(y_test, dtype="float64").reset_index(drop=True)
+    results["predicted_walks"] = pd.Series(y_pred, dtype="float64").reset_index(drop=True)
+    results["error"] = results["predicted_walks"] - results["actual_walks"]
+    results["abs_error"] = results["error"].abs()
+    return results
+
+
+def _build_error_bucket_summary(results_df: pd.DataFrame) -> list[dict]:
+    working = results_df.copy()
+    bins = [-float("inf"), 1.5, 2.5, 3.5, 4.5, float("inf")]
+    labels = ["<=1.5", "1.5-2.5", "2.5-3.5", "3.5-4.5", "4.5+"]
+    working["error_bucket"] = pd.cut(
+        working["predicted_walks"],
+        bins=bins,
+        labels=labels,
+        include_lowest=True,
+        right=True,
+    )
+    summary = (
+        working.groupby("error_bucket", observed=False)
+        .agg(
+            rows=("predicted_walks", "size"),
+            mean_actual=("actual_walks", "mean"),
+            mean_prediction=("predicted_walks", "mean"),
+            mae=("abs_error", "mean"),
+            bias=("error", "mean"),
+        )
+        .reset_index()
+    )
+    summary = summary[summary["rows"] > 0]
+    summary["error_bucket"] = summary["error_bucket"].astype(str)
+    return summary.to_dict(orient="records")
+
+
+def _evaluation_metrics(train_output: dict, *, train_df: pd.DataFrame, test_df: pd.DataFrame) -> dict:
+    y_train = train_output["y_train"]
+    y_test = train_output["y_test"]
+    y_pred_train = train_output["model"].predict(train_output["dtrain"])
+    y_pred_test = train_output["model"].predict(train_output["dtest"])
+
+    test_results = _build_prediction_results(test_df, y_test, y_pred_test)
+    interval_config = fit_interval_calibration(
+        train_df,
+        y_train,
+        y_pred_train,
+        stddev_column=UNCERTAINTY_STDDEV_COLUMN,
+    )
+
+    return {
+        "regression": evaluate_predictions(y_test, y_pred_test),
+        "bucketed_error": {
+            "bucket_by": "predicted_walks",
+            "buckets": _build_error_bucket_summary(test_results),
+        },
+        "uncertainty": summarize_interval_coverage(
+            test_df,
+            y_test,
+            y_pred_test,
+            interval_config,
+            stddev_column=UNCERTAINTY_STDDEV_COLUMN,
+        ),
+        "workflow_backtest": {
+            "available": False,
+            "reason": "pitcher_walks_historical_backtest_not_yet_wired",
+            "reproducible_path": None,
+        },
+        "sample_sizes": {
+            "train_rows": int(len(train_output["X_train"])),
+            "test_rows": int(len(train_output["X_test"])),
+        },
+    }
+
+
+def build_training_metadata(
+    model_df: pd.DataFrame,
+    train_df: pd.DataFrame,
+    test_df: pd.DataFrame,
+    train_output: dict,
+    historical_lines_df: pd.DataFrame | None = None,
+) -> dict:
+    uncertainty_model = fit_interval_calibration(
+        train_df,
+        train_output["y_train"],
+        train_output["model"].predict(train_output["dtrain"]),
+        stddev_column=UNCERTAINTY_STDDEV_COLUMN,
+    )
+    uncertainty_model["documented_interpretation"] = (
+        "lower_bound and upper_bound represent an empirical central prediction "
+        "interval targeting 80% coverage on held-out data when the recent walk "
+        "standard deviation signal is present."
+    )
+
+    return {
+        "target": TARGET_COL,
+        "features": BASE_FEATURES,
+        "model_params": {
+            "xgb_params": XGB_PARAMS,
+            "num_boost_round": 200,
+        },
+        "training_window": {
+            "raw_statcast_start": RAW_STATCAST_START,
+            "raw_statcast_end": RAW_STATCAST_END,
+            "train_split_date": TRAIN_SPLIT_DATE,
+            "model_df_rows": int(len(model_df)),
+            "train_rows": int(len(train_df)),
+            "test_rows": int(len(test_df)),
+            "train_game_date_range": _date_range(train_df),
+            "test_game_date_range": _date_range(test_df),
+        },
+        "evaluation_metrics": _evaluation_metrics(
+            train_output,
+            train_df=train_df,
+            test_df=test_df,
+        ),
+        "uncertainty_model": uncertainty_model,
+        "historical_lines_artifact": {
+            "selection_rule": "latest_pregame_snapshot_per_game_player_book_side",
+            "source_directory": str(RAW_HISTORICAL_LINES_DIR),
+            "rows": int(len(historical_lines_df)) if historical_lines_df is not None else 0,
+            "limitations": (
+                "v1 stores one selected line per game_date x player x sportsbook x side. "
+                "It does not persist full snapshot history or intraday replay data."
+            ),
+        },
+    }
+
+
+def train_pitcher_bb_model(
+    pitcher_games: pd.DataFrame,
+    historical_lines_df: pd.DataFrame | None = None,
+):
+    starter_like_pitcher_games = filter_starter_like_appearances(pitcher_games)
+    model_df = build_model_df(starter_like_pitcher_games)
+    train_df, test_df = time_split(model_df)
+
+    if train_df.empty or test_df.empty:
+        raise ValueError(
+            "Starter-like filtering produced an empty train/test split. "
+            f"Expected non-empty rows on both sides of {TRAIN_SPLIT_DATE}."
+        )
+
+    train_output = train_model(train_df, test_df)
+    metadata = build_training_metadata(
+        model_df=model_df,
+        train_df=train_df,
+        test_df=test_df,
+        train_output=train_output,
+        historical_lines_df=historical_lines_df,
+    )
+    return train_output["model"], model_df, metadata
+
+
+def save_artifacts_to_dir(
+    output_dir: Path,
+    pitcher_games: pd.DataFrame,
+    model_df: pd.DataFrame,
+    historical_lines_df: pd.DataFrame,
+    model,
+    metadata: dict,
+) -> dict[str, Path]:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    paths = artifact_paths(output_dir)
+    pitcher_games.to_csv(paths["pitcher_games"], index=False)
+    model_df.to_csv(paths["model_df"], index=False)
+    historical_lines_df.to_csv(paths["historical_lines"], index=False)
+    model.save_model(str(paths["model"]))
+    paths["metadata"].write_text(json.dumps(metadata, indent=2), encoding="utf-8")
+    return paths
+
+
+def build_training_artifacts() -> dict[str, Path]:
+    ensure_artifact_dirs()
+    if STAGING_DIR.exists():
+        shutil.rmtree(STAGING_DIR)
+    STAGING_DIR.mkdir(parents=True, exist_ok=True)
+
+    pitcher_games = build_historical_pitcher_games()
+    historical_lines_df = build_native_historical_lines()
+    model, model_df, metadata = train_pitcher_bb_model(
+        pitcher_games,
+        historical_lines_df=historical_lines_df,
+    )
+
+    promote_latest_to_previous()
+    save_artifacts_to_dir(
+        output_dir=STAGING_DIR,
+        pitcher_games=pitcher_games,
+        model_df=model_df,
+        historical_lines_df=historical_lines_df,
+        model=model,
+        metadata=metadata,
+    )
+    promote_staging_to_latest()
+    return artifact_paths(LATEST_DIR)
+
+
+if __name__ == "__main__":
+    paths = build_training_artifacts()
+    print("Saved pitcher walks training artifacts:")
+    for name, path in paths.items():
+        print(f"- {name}: {path}")

--- a/MLB/src/pitcher_bb/config.py
+++ b/MLB/src/pitcher_bb/config.py
@@ -5,18 +5,21 @@ PITCHER_BB_PROP_MARKET = "pitcher_walks"
 STARTER_LIKE_MIN_PITCHES = 40
 STARTER_LIKE_MIN_BATTERS_FACED = 12
 
-# Walk-specific rolling features are not engineered in the current shared
-# pipeline yet, so start with stable workload/context columns that already
-# exist in the pitcher feature set.
+# Build on the shared pitcher-game pipeline using walk-specific rolling and
+# opponent-context features plus a small workload baseline.
 BASE_FEATURES = [
     "pitches_last3",
     "pitches_last10",
     "batters_faced_last3",
     "batters_faced_last10",
+    "walks_last3",
+    "walks_last10",
     "avg_velo_last3",
     "avg_spin_last3",
-    "opp_strikeouts_per_game_last10",
-    "opp_k_rate_last10",
+    "bb_per_pitch_last10",
+    "bb_rate_last10",
+    "opp_walks_per_game_last10",
+    "opp_bb_rate_last10",
 ]
 
 TARGET_COL = "walks"

--- a/MLB/src/pitcher_bb/feature_engineering.py
+++ b/MLB/src/pitcher_bb/feature_engineering.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import pandas as pd
+
+from common.contracts import require_columns, validate_pitcher_games_contract
+from pitcher_k.feature_engineering import (
+    add_opponent_bb_features,
+    add_pitcher_team_info,
+    add_rate_features,
+    add_rolling_pitcher_features,
+    build_pitcher_game_table,
+    filter_starter_like_appearances,
+)
+
+
+def build_pitcher_walk_game_table(sc: pd.DataFrame) -> pd.DataFrame:
+    pitcher_games = build_pitcher_game_table(sc)
+    require_columns(pitcher_games, ["walks"], "pitcher_games")
+    return pitcher_games
+
+
+def build_pitcher_walk_feature_table(sc: pd.DataFrame) -> pd.DataFrame:
+    pitcher_games = build_pitcher_walk_game_table(sc)
+    pitcher_games = add_pitcher_team_info(pitcher_games, sc)
+    pitcher_games = add_opponent_bb_features(pitcher_games, sc)
+    pitcher_games = add_rolling_pitcher_features(pitcher_games)
+    pitcher_games = add_rate_features(pitcher_games)
+    validate_pitcher_games_contract(pitcher_games)
+    require_columns(
+        pitcher_games,
+        [
+            "walks",
+            "walks_last3",
+            "walks_last10",
+            "walks_stddev_last10",
+            "walks_p25_last10",
+            "walks_p75_last10",
+            "bb_per_pitch_last10",
+            "bb_rate_last10",
+            "opp_walks_per_game_last10",
+            "opp_bb_rate_last10",
+        ],
+        "pitcher_games",
+    )
+    return pitcher_games
+
+
+__all__ = [
+    "build_pitcher_walk_game_table",
+    "build_pitcher_walk_feature_table",
+    "filter_starter_like_appearances",
+]

--- a/MLB/src/pitcher_bb/feature_model.py
+++ b/MLB/src/pitcher_bb/feature_model.py
@@ -1,0 +1,36 @@
+import numpy as np
+import pandas as pd
+
+from .config import BASE_FEATURES, TARGET_COL
+
+UNCERTAINTY_FEATURE_COLUMNS = [
+    "walks_stddev_last10",
+    "walks_p25_last10",
+    "walks_p75_last10",
+]
+
+
+def get_feature_columns() -> list[str]:
+    return list(BASE_FEATURES)
+
+
+def build_model_df(pitcher_games: pd.DataFrame) -> pd.DataFrame:
+    features = get_feature_columns()
+
+    keep_cols = [
+        "game_date",
+        "game_pk",
+        "pitcher",
+        "player_name",
+        TARGET_COL,
+    ] + features
+
+    extra_cols = [col for col in UNCERTAINTY_FEATURE_COLUMNS if col in pitcher_games.columns]
+    keep_cols = keep_cols + [col for col in extra_cols if col not in keep_cols]
+
+    model_df = pitcher_games[keep_cols].copy()
+    model_df["game_date"] = pd.to_datetime(model_df["game_date"])
+    model_df = model_df.replace([np.inf, -np.inf], np.nan)
+    model_df = model_df.dropna(subset=[TARGET_COL] + features)
+    model_df = model_df.sort_values("game_date")
+    return model_df

--- a/MLB/src/pitcher_bb/preprocessing.py
+++ b/MLB/src/pitcher_bb/preprocessing.py
@@ -1,0 +1,3 @@
+from pitcher_k.preprocessing import add_outcome_flags
+
+__all__ = ["add_outcome_flags"]

--- a/MLB/src/pitcher_bb/train.py
+++ b/MLB/src/pitcher_bb/train.py
@@ -1,0 +1,66 @@
+import pandas as pd
+import xgboost as xgb
+
+from .config import BASE_FEATURES, TARGET_COL, TRAIN_SPLIT_DATE, XGB_PARAMS
+
+
+def time_split(model_df: pd.DataFrame, split_date: str = TRAIN_SPLIT_DATE):
+    train_df = model_df[model_df["game_date"] < split_date].copy()
+    test_df = model_df[model_df["game_date"] >= split_date].copy()
+    return train_df, test_df
+
+
+def make_xy(df: pd.DataFrame, features: list[str] = BASE_FEATURES, target: str = TARGET_COL):
+    X = df[features].copy()
+    y = df[target].copy()
+    return X, y
+
+
+def make_dmats(
+    train_df: pd.DataFrame,
+    test_df: pd.DataFrame,
+    features: list[str] = BASE_FEATURES,
+    target: str = TARGET_COL,
+):
+    X_train, y_train = make_xy(train_df, features, target)
+    X_test, y_test = make_xy(test_df, features, target)
+
+    dtrain = xgb.DMatrix(X_train, label=y_train, feature_names=features)
+    dtest = xgb.DMatrix(X_test, label=y_test, feature_names=features)
+
+    return dtrain, dtest, X_train, X_test, y_train, y_test
+
+
+def train_model(
+    train_df: pd.DataFrame,
+    test_df: pd.DataFrame,
+    features: list[str] = BASE_FEATURES,
+    target: str = TARGET_COL,
+    params: dict = XGB_PARAMS,
+    num_boost_round: int = 200,
+):
+    dtrain, dtest, X_train, X_test, y_train, y_test = make_dmats(
+        train_df=train_df,
+        test_df=test_df,
+        features=features,
+        target=target,
+    )
+
+    evals = [(dtrain, "train"), (dtest, "test")]
+    model = xgb.train(
+        params=params,
+        dtrain=dtrain,
+        num_boost_round=num_boost_round,
+        evals=evals,
+        verbose_eval=False,
+    )
+
+    return {
+        "model": model,
+        "dtrain": dtrain,
+        "dtest": dtest,
+        "X_train": X_train,
+        "X_test": X_test,
+        "y_train": y_train,
+        "y_test": y_test,
+    }

--- a/MLB/src/pitcher_k/feature_engineering.py
+++ b/MLB/src/pitcher_k/feature_engineering.py
@@ -14,6 +14,7 @@ from common.contracts import (
 )
 from common.identity import normalize_participant_name
 from .config import STARTER_LIKE_MIN_BATTERS_FACED, STARTER_LIKE_MIN_PITCHES
+from .preprocessing import add_outcome_flags
 
 
 def build_pitcher_game_table(sc: pd.DataFrame) -> pd.DataFrame:
@@ -28,8 +29,8 @@ def build_pitcher_game_table(sc: pd.DataFrame) -> pd.DataFrame:
             "pitcher",
             "player_name",
             "pitch_type",
-            "is_k",
-            "is_whiff",
+            "description",
+            "events",
             "release_speed",
             "release_spin_rate",
             "batter",
@@ -40,12 +41,14 @@ def build_pitcher_game_table(sc: pd.DataFrame) -> pd.DataFrame:
         "statcast_df",
     )
     assert_non_empty(sc, "statcast_df")
+    sc = add_outcome_flags(sc)
 
     pitcher_games = (
         sc.groupby(["game_date", "game_pk", "pitcher", "player_name"])
         .agg(
             pitches=("pitch_type", "count"),
             strikeouts=("is_k", "sum"),
+            walks=("is_bb", "sum"),
             whiffs=("is_whiff", "sum"),
             avg_velo=("release_speed", "mean"),
             avg_spin=("release_spin_rate", "mean"),
@@ -174,10 +177,11 @@ def add_pitcher_team_info(pitcher_games: pd.DataFrame, sc: pd.DataFrame) -> pd.D
 def build_team_offense_k_table(sc: pd.DataFrame) -> pd.DataFrame:
     require_columns(
         sc,
-        ["game_date", "game_pk", "inning_topbot", "away_team", "home_team", "is_k", "batter"],
+        ["game_date", "game_pk", "inning_topbot", "away_team", "home_team", "description", "events", "batter"],
         "statcast_df",
     )
     assert_non_empty(sc, "statcast_df")
+    sc = add_outcome_flags(sc)
 
     temp = sc.reset_index(drop=True).copy()
 
@@ -232,6 +236,64 @@ def build_team_offense_k_table(sc: pd.DataFrame) -> pd.DataFrame:
     return team_offense
 
 
+def build_team_offense_bb_table(sc: pd.DataFrame) -> pd.DataFrame:
+    require_columns(
+        sc,
+        ["game_date", "game_pk", "inning_topbot", "away_team", "home_team", "description", "events", "batter"],
+        "statcast_df",
+    )
+    assert_non_empty(sc, "statcast_df")
+    sc = add_outcome_flags(sc)
+
+    temp = sc.reset_index(drop=True).copy()
+    temp["batting_team"] = np.where(
+        temp["inning_topbot"] == "Top",
+        temp["away_team"],
+        temp["home_team"],
+    )
+
+    team_offense = (
+        temp.groupby(["game_date", "game_pk", "batting_team"], as_index=False)
+        .agg(
+            team_batter_walks=("is_bb", "sum"),
+            batters_faced=("batter", "nunique"),
+        )
+    )
+    team_offense["team_bb_rate"] = (
+        team_offense["team_batter_walks"] / team_offense["batters_faced"]
+    )
+    team_offense["team_bb_rate"] = team_offense["team_bb_rate"].replace([np.inf, -np.inf], np.nan)
+    team_offense = team_offense.sort_values(["batting_team", "game_date"]).copy()
+
+    team_offense["opp_walks_per_game_last10"] = (
+        team_offense.groupby("batting_team")["team_batter_walks"]
+        .transform(lambda s: s.shift(1).rolling(10, min_periods=3).mean())
+    )
+    team_offense["opp_bb_rate_last10"] = (
+        team_offense.groupby("batting_team")["team_bb_rate"]
+        .transform(lambda s: s.shift(1).rolling(10, min_periods=3).mean())
+    )
+
+    require_columns(
+        team_offense,
+        [
+            "game_date",
+            "game_pk",
+            "batting_team",
+            "opp_walks_per_game_last10",
+            "opp_bb_rate_last10",
+        ],
+        "team_offense",
+    )
+    assert_no_duplicate_keys(
+        team_offense,
+        ["game_date", "game_pk", "batting_team"],
+        "team_offense",
+    )
+
+    return team_offense
+
+
 def add_opponent_k_features(pitcher_games: pd.DataFrame, sc: pd.DataFrame) -> pd.DataFrame:
     require_columns(
         pitcher_games,
@@ -267,6 +329,40 @@ def add_opponent_k_features(pitcher_games: pd.DataFrame, sc: pd.DataFrame) -> pd
     return pitcher_games
 
 
+def add_opponent_bb_features(pitcher_games: pd.DataFrame, sc: pd.DataFrame) -> pd.DataFrame:
+    require_columns(
+        pitcher_games,
+        ["game_date", "game_pk", "opponent_team"],
+        "pitcher_games",
+    )
+    assert_non_empty(pitcher_games, "pitcher_games")
+
+    team_offense = build_team_offense_bb_table(sc)
+    opp_features = team_offense.rename(columns={"batting_team": "opponent_team"})[
+        [
+            "game_date",
+            "game_pk",
+            "opponent_team",
+            "opp_walks_per_game_last10",
+            "opp_bb_rate_last10",
+        ]
+    ]
+
+    pitcher_games = pitcher_games.merge(
+        opp_features,
+        on=["game_date", "game_pk", "opponent_team"],
+        how="left",
+    )
+
+    require_columns(
+        pitcher_games,
+        ["opp_walks_per_game_last10", "opp_bb_rate_last10"],
+        "pitcher_games",
+    )
+
+    return pitcher_games
+
+
 def add_rolling_pitcher_features(pitcher_games: pd.DataFrame) -> pd.DataFrame:
     """
     Add trailing rolling features using prior games only.
@@ -277,6 +373,7 @@ def add_rolling_pitcher_features(pitcher_games: pd.DataFrame) -> pd.DataFrame:
             "pitcher",
             "game_date",
             "strikeouts",
+            "walks",
             "pitches",
             "batters_faced",
             "whiff_per_pitch",
@@ -291,6 +388,7 @@ def add_rolling_pitcher_features(pitcher_games: pd.DataFrame) -> pd.DataFrame:
 
     rolling_cols = [
         "strikeouts",
+        "walks",
         "pitches",
         "batters_faced",
         "whiff_per_pitch",
@@ -319,6 +417,16 @@ def add_rolling_pitcher_features(pitcher_games: pd.DataFrame) -> pd.DataFrame:
     pitcher_games["strikeouts_p75_last10"] = pitcher_games.groupby("pitcher")["strikeouts"].transform(
         lambda s: s.shift(1).rolling(10, min_periods=3).quantile(0.75)
     )
+    walks_history = pitcher_games.groupby("pitcher")["walks"].transform(
+        lambda s: s.shift(1).rolling(10, min_periods=3).std(ddof=0)
+    )
+    pitcher_games["walks_stddev_last10"] = walks_history
+    pitcher_games["walks_p25_last10"] = pitcher_games.groupby("pitcher")["walks"].transform(
+        lambda s: s.shift(1).rolling(10, min_periods=3).quantile(0.25)
+    )
+    pitcher_games["walks_p75_last10"] = pitcher_games.groupby("pitcher")["walks"].transform(
+        lambda s: s.shift(1).rolling(10, min_periods=3).quantile(0.75)
+    )
 
     require_columns(
         pitcher_games,
@@ -333,6 +441,10 @@ def add_rolling_pitcher_features(pitcher_games: pd.DataFrame) -> pd.DataFrame:
             "strikeouts_stddev_last10",
             "strikeouts_p25_last10",
             "strikeouts_p75_last10",
+            "walks_last10",
+            "walks_stddev_last10",
+            "walks_p25_last10",
+            "walks_p75_last10",
         ],
         "pitcher_games",
     )
@@ -369,10 +481,25 @@ def add_rate_features(pitcher_games: pd.DataFrame) -> pd.DataFrame:
         [np.inf, -np.inf],
         np.nan,
     )
+    if "walks_last10" in pitcher_games.columns:
+        pitcher_games["bb_per_pitch_last10"] = (
+            pitcher_games["walks_last10"] / pitcher_games["pitches_last10"]
+        )
+        pitcher_games["bb_rate_last10"] = (
+            pitcher_games["walks_last10"] / pitcher_games["batters_faced_last10"]
+        )
+        pitcher_games["bb_per_pitch_last10"] = pitcher_games["bb_per_pitch_last10"].replace(
+            [np.inf, -np.inf],
+            np.nan,
+        )
+        pitcher_games["bb_rate_last10"] = pitcher_games["bb_rate_last10"].replace(
+            [np.inf, -np.inf],
+            np.nan,
+        )
 
     require_columns(
         pitcher_games,
-        ["k_per_pitch_last10", "k_rate_last10"],
+        ["k_per_pitch_last10", "k_rate_last10", "bb_per_pitch_last10", "bb_rate_last10"],
         "pitcher_games",
     )
 

--- a/MLB/src/pitcher_k/preprocessing.py
+++ b/MLB/src/pitcher_k/preprocessing.py
@@ -5,13 +5,18 @@ import pandas as pd
 
 def add_outcome_flags(sc: pd.DataFrame) -> pd.DataFrame:
     """
-    Add strikeout and whiff indicator columns to pitch-level Statcast data.
+    Add strikeout, walk, and whiff indicator columns to pitch-level Statcast data.
     """
     sc = sc.copy()
 
     sc["is_k"] = sc["events"].isin([
         "strikeout",
         "strikeout_double_play"
+    ]).astype(int)
+
+    sc["is_bb"] = sc["events"].isin([
+        "walk",
+        "intent_walk",
     ]).astype(int)
 
     sc["is_whiff"] = sc["description"].isin([

--- a/MLB/tests/jobs/test_build_training_artifacts_pitcher_bb.py
+++ b/MLB/tests/jobs/test_build_training_artifacts_pitcher_bb.py
@@ -1,0 +1,222 @@
+import json
+
+import pandas as pd
+import pytest
+
+from jobs import build_training_artifacts_pitcher_bb as training_job
+
+
+class FakeModel:
+    def save_model(self, path: str) -> None:
+        with open(path, "w", encoding="utf-8") as handle:
+            handle.write("fake-model")
+
+
+class FakePredictModel:
+    def predict(self, dmatrix):
+        if dmatrix == "train":
+            return pd.Series([1.8, 2.2], dtype="float64")
+        if dmatrix == "test":
+            return pd.Series([2.4, 2.9], dtype="float64")
+        raise AssertionError(f"Unexpected dmatrix: {dmatrix}")
+
+
+def test_save_artifacts_to_dir_writes_pitcher_bb_metadata(tmp_path):
+    output_dir = tmp_path / "artifacts"
+    pitcher_games = pd.DataFrame([{"game_date": "2026-04-19", "pitcher": 1, "walks": 2}])
+    model_df = pd.DataFrame([{"game_date": "2026-04-19", "walks": 2}])
+    historical_lines_df = pd.DataFrame()
+    metadata = {
+        "target": "walks",
+        "features": ["walks_last3"],
+        "model_params": {"xgb_params": {"max_depth": 4}},
+        "training_window": {"train_split_date": "2025-08-01"},
+        "evaluation_metrics": {"regression": {"mae": 0.5}},
+    }
+
+    paths = training_job.save_artifacts_to_dir(
+        output_dir=output_dir,
+        pitcher_games=pitcher_games,
+        model_df=model_df,
+        historical_lines_df=historical_lines_df,
+        model=FakeModel(),
+        metadata=metadata,
+    )
+
+    saved_metadata = json.loads(paths["metadata"].read_text(encoding="utf-8"))
+    assert paths["metadata"].exists()
+    assert saved_metadata == metadata
+
+
+def test_build_training_metadata_uses_walk_target_and_features():
+    model_df = pd.DataFrame(
+        [
+            {"game_date": "2025-07-30", "walks": 2, "walks_stddev_last10": 0.6},
+            {"game_date": "2025-07-31", "walks": 3, "walks_stddev_last10": 0.7},
+            {"game_date": "2025-08-02", "walks": 2, "walks_stddev_last10": 0.5},
+            {"game_date": "2025-08-03", "walks": 4, "walks_stddev_last10": 0.9},
+        ]
+    )
+    train_df = pd.DataFrame(
+        [
+            {"game_date": "2025-07-30", "walks": 2, "walks_stddev_last10": 0.6},
+            {"game_date": "2025-07-31", "walks": 3, "walks_stddev_last10": 0.7},
+        ]
+    )
+    test_df = pd.DataFrame(
+        [
+            {"game_date": "2025-08-02", "walks": 2, "walks_stddev_last10": 0.5},
+            {"game_date": "2025-08-03", "walks": 4, "walks_stddev_last10": 0.9},
+        ]
+    )
+    train_output = {
+        "model": FakePredictModel(),
+        "dtrain": "train",
+        "dtest": "test",
+        "X_train": pd.DataFrame([{"walks_last3": 1.5}, {"walks_last3": 2.0}]),
+        "X_test": pd.DataFrame([{"walks_last3": 2.2}, {"walks_last3": 2.7}]),
+        "y_train": pd.Series([2.0, 3.0], dtype="float64"),
+        "y_test": pd.Series([2.0, 4.0], dtype="float64"),
+    }
+
+    metadata = training_job.build_training_metadata(
+        model_df=model_df,
+        train_df=train_df,
+        test_df=test_df,
+        train_output=train_output,
+        historical_lines_df=pd.DataFrame(),
+    )
+
+    assert metadata["target"] == "walks"
+    assert "walks_last3" not in metadata["features"] or isinstance(metadata["features"], list)
+    assert metadata["uncertainty_model"]["base_stddev_column"] == "walks_stddev_last10"
+    assert metadata["evaluation_metrics"]["bucketed_error"]["bucket_by"] == "predicted_walks"
+    assert metadata["evaluation_metrics"]["workflow_backtest"]["available"] is False
+
+
+def test_train_pitcher_bb_model_filters_to_starter_like_appearances(monkeypatch):
+    pitcher_games = pd.DataFrame(
+        [
+            {
+                "game_date": "2025-07-30",
+                "game_pk": 1,
+                "pitcher": 111,
+                "player_name": "Starter One",
+                "walks": 2,
+                "pitches": 91,
+                "batters_faced": 25,
+                "pitches_last3": 92.0,
+                "pitches_last10": 94.0,
+                "batters_faced_last3": 24.0,
+                "batters_faced_last10": 25.0,
+                "walks_last3": 2.0,
+                "walks_last10": 2.1,
+                "avg_velo_last3": 97.1,
+                "avg_spin_last3": 2450.0,
+                "bb_per_pitch_last10": 0.02,
+                "bb_rate_last10": 0.08,
+                "opp_walks_per_game_last10": 3.2,
+                "opp_bb_rate_last10": 0.09,
+                "walks_stddev_last10": 0.6,
+                "walks_p25_last10": 1.5,
+                "walks_p75_last10": 2.5,
+            },
+            {
+                "game_date": "2025-08-02",
+                "game_pk": 2,
+                "pitcher": 111,
+                "player_name": "Starter One",
+                "walks": 1,
+                "pitches": 19,
+                "batters_faced": 5,
+                "pitches_last3": 19.0,
+                "pitches_last10": 19.0,
+                "batters_faced_last3": 5.0,
+                "batters_faced_last10": 5.0,
+                "walks_last3": 1.0,
+                "walks_last10": 1.0,
+                "avg_velo_last3": 96.0,
+                "avg_spin_last3": 2430.0,
+                "bb_per_pitch_last10": 0.05,
+                "bb_rate_last10": 0.20,
+                "opp_walks_per_game_last10": 2.8,
+                "opp_bb_rate_last10": 0.07,
+                "walks_stddev_last10": 0.2,
+                "walks_p25_last10": 1.0,
+                "walks_p75_last10": 1.0,
+            },
+        ]
+    )
+
+    captured = {}
+
+    def fake_train_model(train_df, test_df):
+        captured["train_df"] = train_df.copy()
+        captured["test_df"] = test_df.copy()
+        return {
+            "model": FakePredictModel(),
+            "dtrain": "train",
+            "dtest": "test",
+            "X_train": pd.DataFrame([{"walks_last3": 2.0, "walks_stddev_last10": 0.6}]),
+            "X_test": pd.DataFrame([{"walks_last3": 2.1, "walks_stddev_last10": 0.7}]),
+            "y_train": pd.Series([2.0], dtype="float64"),
+            "y_test": pd.Series([3.0], dtype="float64"),
+        }
+
+    def fake_time_split(model_df):
+        captured["model_df"] = model_df.copy()
+        return model_df.iloc[:1].copy(), model_df.iloc[:1].copy()
+
+    monkeypatch.setattr(training_job, "time_split", fake_time_split)
+    monkeypatch.setattr(training_job, "train_model", fake_train_model)
+    monkeypatch.setattr(training_job, "build_training_metadata", lambda **kwargs: {"ok": True})
+
+    _, model_df, metadata = training_job.train_pitcher_bb_model(
+        pitcher_games,
+        historical_lines_df=pd.DataFrame(),
+    )
+
+    assert metadata == {"ok": True}
+    assert len(model_df) == 1
+    assert model_df["game_pk"].tolist() == [1]
+    assert captured["model_df"]["game_pk"].tolist() == [1]
+
+
+def test_train_pitcher_bb_model_raises_when_starter_filtering_leaves_empty_held_out_split():
+    pitcher_games = pd.DataFrame(
+        [
+            {
+                "game_date": "2025-08-03",
+                "game_pk": 2,
+                "pitcher": 111,
+                "player_name": "Starter One",
+                "walks": 1,
+                "pitches": 19,
+                "batters_faced": 5,
+                "pitches_last3": 19.0,
+                "pitches_last10": 19.0,
+                "batters_faced_last3": 5.0,
+                "batters_faced_last10": 5.0,
+                "walks_last3": 1.0,
+                "walks_last10": 1.0,
+                "avg_velo_last3": 96.0,
+                "avg_spin_last3": 2430.0,
+                "bb_per_pitch_last10": 0.05,
+                "bb_rate_last10": 0.20,
+                "opp_walks_per_game_last10": 2.8,
+                "opp_bb_rate_last10": 0.07,
+                "walks_stddev_last10": 0.2,
+                "walks_p25_last10": 1.0,
+                "walks_p75_last10": 1.0,
+            },
+        ]
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="Starter-like filtering produced an empty train/test split",
+    ):
+        training_job.train_pitcher_bb_model(
+            pitcher_games,
+            historical_lines_df=pd.DataFrame(),
+        )

--- a/MLB/tests/pitcher_bb/test_pitcher_bb_feature_engineering.py
+++ b/MLB/tests/pitcher_bb/test_pitcher_bb_feature_engineering.py
@@ -1,0 +1,110 @@
+import pandas as pd
+import pytest
+
+from pitcher_bb.feature_engineering import (
+    build_pitcher_walk_feature_table,
+    build_pitcher_walk_game_table,
+)
+
+
+def _statcast_df() -> pd.DataFrame:
+    rows = []
+    walk_pattern = {
+        "2026-04-10": {1},
+        "2026-04-11": {1, 2},
+        "2026-04-12": {1},
+        "2026-04-13": {1, 2, 3},
+    }
+    opp_walk_pattern = {
+        "2026-04-10": {11},
+        "2026-04-11": {11, 12},
+        "2026-04-12": {11},
+        "2026-04-13": {11, 12, 13},
+    }
+
+    for game_idx, game_date in enumerate(
+        ["2026-04-10", "2026-04-11", "2026-04-12", "2026-04-13"],
+        start=1,
+    ):
+        game_pk = 3000 + game_idx
+
+        for batter_id in range(1, 6):
+            event = "walk" if batter_id in walk_pattern[game_date] else "field_out"
+            rows.append(
+                {
+                    "game_date": game_date,
+                    "game_pk": game_pk,
+                    "pitcher": 111,
+                    "player_name": "Jacob deGrom",
+                    "batter": batter_id,
+                    "pitch_type": "FF",
+                    "release_speed": 97.0 + game_idx,
+                    "release_spin_rate": 2450 + game_idx,
+                    "description": "ball" if event == "walk" else "called_strike",
+                    "events": event,
+                    "inning": 1,
+                    "outs_when_up": 0,
+                    "home_team": "TEX",
+                    "away_team": "SEA",
+                    "stand": "R",
+                    "p_throws": "R",
+                    "inning_topbot": "Top",
+                }
+            )
+
+        for batter_id in range(11, 16):
+            event = "walk" if batter_id in opp_walk_pattern[game_date] else "single"
+            rows.append(
+                {
+                    "game_date": game_date,
+                    "game_pk": game_pk,
+                    "pitcher": 222,
+                    "player_name": "Logan Gilbert",
+                    "batter": batter_id,
+                    "pitch_type": "FF",
+                    "release_speed": 95.0 + game_idx,
+                    "release_spin_rate": 2350 + game_idx,
+                    "description": "ball" if event == "walk" else "in_play",
+                    "events": event,
+                    "inning": 1,
+                    "outs_when_up": 0,
+                    "home_team": "TEX",
+                    "away_team": "SEA",
+                    "stand": "L",
+                    "p_throws": "R",
+                    "inning_topbot": "Bottom",
+                }
+            )
+
+    return pd.DataFrame(rows)
+
+
+def test_build_pitcher_walk_game_table_adds_walk_target():
+    pitcher_games = build_pitcher_walk_game_table(_statcast_df())
+
+    assert "walks" in pitcher_games.columns
+    degrom_row = pitcher_games.loc[pitcher_games["game_pk"] == 3001].iloc[0]
+    assert degrom_row["walks"] == 1
+
+
+def test_build_pitcher_walk_feature_table_adds_walk_specific_features():
+    pitcher_games = build_pitcher_walk_feature_table(_statcast_df())
+
+    expected_cols = {
+        "walks",
+        "walks_last3",
+        "walks_last10",
+        "walks_stddev_last10",
+        "walks_p25_last10",
+        "walks_p75_last10",
+        "bb_per_pitch_last10",
+        "bb_rate_last10",
+        "opp_walks_per_game_last10",
+        "opp_bb_rate_last10",
+    }
+    assert expected_cols.issubset(pitcher_games.columns)
+
+    degrom_rows = pitcher_games[pitcher_games["pitcher"] == 111].sort_values("game_pk").reset_index(drop=True)
+    assert pd.isna(degrom_rows.loc[2, "walks_stddev_last10"])
+    assert degrom_rows.loc[3, "walks_last10"] == pytest.approx(pd.Series([1.0, 2.0, 1.0]).mean())
+    assert degrom_rows.loc[3, "walks_stddev_last10"] == pytest.approx(pd.Series([1.0, 2.0, 1.0]).std(ddof=0))


### PR DESCRIPTION
The current pitcher_bb scaffold was the right starting point, but the most maintainable path was not to fork the full pitcher_k stack. I implemented pitcher walks as a sibling workflow that reuses the shared Statcast-to-pitcher-game layer, then layers BB-specific target/features/training on top. That keeps the low-level aggregation logic in one place while giving walks its own config, model-building, and artifact job.

The shared pitcher pipeline now derives walk outcomes and walk rolling features in preprocessing.py (line 6) and feature_engineering.py (line 16), including walks, walks_last3, walks_last10, walks_stddev_last10, bb_per_pitch_last10, bb_rate_last10, opp_walks_per_game_last10, and opp_bb_rate_last10. On top of that, I added the pitcher-walk-specific modules in pitcher_bb: config.py (line 1), feature_engineering.py (line 1), feature_model.py (line 1), and train.py (line 1). I also added a dedicated artifact workflow in build_training_artifacts_pitcher_bb.py (line 1) that saves to MLB/data/artifacts/pitcher_bb/... so it won’t collide with strikeout artifacts.

I updated the supported-props note in supported_props.md (line 1) and added regression coverage for both walk feature generation and artifact creation in test_pitcher_bb_feature_engineering.py (line 1) and test_build_training_artifacts_pitcher_bb.py (line 1). Verification passed with 24 passed across the new pitcher-BB tests plus the existing pitcher-K feature and training-artifact suites.