### PR TITLE
run_daily_card is now workflow-composable, so multi-prop support is d…

### DIFF
--- a/MLB/src/common/contracts.py
+++ b/MLB/src/common/contracts.py
@@ -40,6 +40,7 @@ JOINED_ODDS_REQUIRED_COLUMNS = [
 
 FINAL_PICKS_REQUIRED_COLUMNS = [
     "player_name",
+    "prop_type",
     "book",
     "pick_side",
     "line",

--- a/MLB/src/common/workflows.py
+++ b/MLB/src/common/workflows.py
@@ -14,6 +14,7 @@ Predictor = Callable[[object, pd.DataFrame], pd.DataFrame]
 ArtifactDataLoader = Callable[[Path], pd.DataFrame]
 ArtifactModelLoader = Callable[[Path], object]
 PredictionMetadataAdjuster = Callable[[pd.DataFrame, dict | None], pd.DataFrame]
+PredictionOutputAdapter = Callable[[pd.DataFrame], pd.DataFrame]
 
 
 @dataclass(frozen=True)
@@ -29,10 +30,12 @@ class WorkflowArtifactSpec:
     model_filename: str
     model_loader: ArtifactModelLoader
     metadata_filename: str = "metadata.json"
+    artifact_subdir: str | None = None
 
 
 @dataclass(frozen=True)
 class ModelingWorkflowSpec:
+    prop_type: str
     sport: str
     participant_key: str
     market_key: str
@@ -45,7 +48,9 @@ class ModelingWorkflowSpec:
     participant_identity: ParticipantIdentitySpec = field(default_factory=ParticipantIdentitySpec)
     market_identity: MarketIdentitySpec = field(default_factory=MarketIdentitySpec)
     prediction_metadata_adjuster: PredictionMetadataAdjuster | None = None
+    prediction_output_adapter: PredictionOutputAdapter | None = None
     postable_limits: PostablePickLimits = field(default_factory=PostablePickLimits)
+    enabled_in_default_daily_card: bool = True
 
     def resolved_postable_limits(self) -> PostablePickLimits:
         return self.postable_limits

--- a/MLB/src/jobs/run_daily_card.py
+++ b/MLB/src/jobs/run_daily_card.py
@@ -35,6 +35,7 @@ from common.identity import (
 )
 from common.workflows import ModelingWorkflowSpec
 from pitcher_k.workflow import MLB_PITCHER_STRIKEOUT_WORKFLOW
+from pitcher_bb.workflow import MLB_PITCHER_WALK_WORKFLOW
 from pitcher_k.data_loader import load_statcast_data
 from pitcher_k.feature_engineering import build_pitcher_game_table
 from pitcher_k.preprocessing import add_outcome_flags
@@ -62,6 +63,7 @@ OFFICIAL_PICKS_HISTORY_COLUMNS = [
     "pick_key",
     "game_date",
     "player_name",
+    "prop_type",
     PARTICIPANT_JOIN_KEY_COLUMN,
     PARTICIPANT_ID_COLUMN,
     PARTICIPANT_SOURCE_ID_COLUMN,
@@ -112,6 +114,10 @@ OFFICIAL_PICKS_PROFIT_SUMMARY_COLUMNS = [
 
 BuildPicksFn = Callable[[pd.DataFrame], pd.DataFrame]
 FilterPostablePicksFn = Callable[[pd.DataFrame], pd.DataFrame]
+DEFAULT_DAILY_CARD_WORKFLOWS = [
+    MLB_PITCHER_STRIKEOUT_WORKFLOW,
+    MLB_PITCHER_WALK_WORKFLOW,
+]
 
 
 def ensure_output_dirs() -> None:
@@ -131,6 +137,38 @@ def empty_joined_odds_df() -> pd.DataFrame:
 
 def empty_final_picks_df() -> pd.DataFrame:
     return pd.DataFrame(columns=FINAL_PICKS_REQUIRED_COLUMNS)
+
+
+def _artifact_dir_candidates(workflow: ModelingWorkflowSpec) -> list[Path]:
+    artifact_subdir = workflow.artifacts.artifact_subdir
+    if artifact_subdir:
+        workflow_root = ARTIFACTS_DIR / artifact_subdir
+        return [
+            workflow_root / "latest",
+            workflow_root / "previous",
+        ]
+    return [
+        LATEST_ARTIFACTS_DIR,
+        PREVIOUS_ARTIFACTS_DIR,
+    ]
+
+
+def _tag_workflow_frame(
+    df: pd.DataFrame,
+    workflow: ModelingWorkflowSpec,
+) -> pd.DataFrame:
+    tagged = df.copy()
+    tagged["prop_type"] = workflow.prop_type
+    return tagged
+
+
+def _adapt_predictions_for_output(
+    today_preds: pd.DataFrame,
+    workflow: ModelingWorkflowSpec,
+) -> pd.DataFrame:
+    adapter = workflow.prediction_output_adapter
+    adapted = adapter(today_preds) if adapter is not None else today_preds.copy()
+    return _tag_workflow_frame(adapted, workflow)
 
 
 def _format_american_odds(price: float | int | str | None) -> str:
@@ -686,10 +724,10 @@ def persist_official_picks_history(
     return OFFICIAL_PICKS_HISTORY_PATH
 
 
-def resolve_artifact_path(filename: str) -> Path:
+def resolve_artifact_path(filename: str, workflow: ModelingWorkflowSpec = MLB_PITCHER_STRIKEOUT_WORKFLOW) -> Path:
     candidate_paths = [
-        LATEST_ARTIFACTS_DIR / filename,
-        PREVIOUS_ARTIFACTS_DIR / filename,
+        candidate_dir / filename
+        for candidate_dir in _artifact_dir_candidates(workflow)
     ]
 
     for path in candidate_paths:
@@ -702,21 +740,21 @@ def resolve_artifact_path(filename: str) -> Path:
 
 
 def load_workflow_history_artifact(workflow: ModelingWorkflowSpec) -> pd.DataFrame:
-    path = resolve_artifact_path(workflow.artifacts.history_filename)
+    path = resolve_artifact_path(workflow.artifacts.history_filename, workflow)
     history_df = workflow.artifacts.history_loader(path)
     print(f"Loaded workflow history artifact from: {path}")
     return history_df
 
 
 def load_workflow_model_artifact(workflow: ModelingWorkflowSpec):
-    path = resolve_artifact_path(workflow.artifacts.model_filename)
+    path = resolve_artifact_path(workflow.artifacts.model_filename, workflow)
     model = workflow.artifacts.model_loader(path)
     print(f"Loaded model artifact from: {path}")
     return model
 
 
 def load_model_metadata(workflow: ModelingWorkflowSpec = MLB_PITCHER_STRIKEOUT_WORKFLOW) -> dict:
-    model_path = resolve_artifact_path(workflow.artifacts.model_filename)
+    model_path = resolve_artifact_path(workflow.artifacts.model_filename, workflow)
     metadata_path = model_path.with_name(workflow.artifacts.metadata_filename)
 
     if not metadata_path.exists():
@@ -824,15 +862,43 @@ def save_outputs(
     save_run_status(status=run_status, message=run_message)
 
 
-def run_daily_card(
+def workflow_is_ready(workflow: ModelingWorkflowSpec) -> bool:
+    try:
+        resolve_artifact_path(workflow.artifacts.history_filename, workflow)
+        resolve_artifact_path(workflow.artifacts.model_filename, workflow)
+        resolve_artifact_path(workflow.artifacts.metadata_filename, workflow)
+    except FileNotFoundError:
+        return False
+    return True
+
+
+def resolve_daily_card_workflows(
+    workflows: list[ModelingWorkflowSpec] | None = None,
+) -> list[ModelingWorkflowSpec]:
+    if workflows is not None:
+        return workflows
+
+    resolved: list[ModelingWorkflowSpec] = []
+    for workflow in DEFAULT_DAILY_CARD_WORKFLOWS:
+        if not workflow.enabled_in_default_daily_card:
+            continue
+        if workflow_is_ready(workflow):
+            resolved.append(workflow)
+
+    if resolved:
+        return resolved
+
+    return [MLB_PITCHER_STRIKEOUT_WORKFLOW]
+
+
+def run_workflow_daily_card(
     *,
-    workflow: ModelingWorkflowSpec = MLB_PITCHER_STRIKEOUT_WORKFLOW,
+    starters_df: pd.DataFrame,
+    workflow: ModelingWorkflowSpec,
     market: str | None = None,
     build_picks_fn: BuildPicksFn | None = None,
     filter_postable_picks_fn: FilterPostablePicksFn | None = None,
-) -> tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame, pd.DataFrame]:
-    ensure_output_dirs()
-
+) -> tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame, str, str | None]:
     if build_picks_fn is None:
         def build_picks_fn(joined_df: pd.DataFrame) -> pd.DataFrame:
             return build_daily_picks(
@@ -851,8 +917,6 @@ def run_daily_card(
                 policy=workflow.pick_ranking_policy,
             )
 
-    starters_df = get_today_starters_df()
-    validate_starters_contract(starters_df)
     history_df = load_workflow_history_artifact(workflow)
     model = load_workflow_model_artifact(workflow)
     metadata = load_model_metadata(workflow)
@@ -868,6 +932,7 @@ def run_daily_card(
     if today_preds.empty:
         raise ValueError("No today predictions were generated.")
 
+    today_preds = _adapt_predictions_for_output(today_preds, workflow)
     selected_market = market or workflow.market_key
     run_status = "success"
     run_message: str | None = None
@@ -881,34 +946,98 @@ def run_daily_card(
             odds_join_key=workflow.projection_odds_join_keys.odds,
             sport=workflow.sport,
         )
+        joined_df = _tag_workflow_frame(joined_df, workflow)
         if joined_df.empty:
             run_status = "degraded"
             run_message = (
                 "Live odds were fetched but no matching odds rows were available for today's "
-                "projections, so no edges or picks were generated."
+                f"{workflow.prop_type} projections, so no edges or picks were generated."
             )
             print(f"WARNING: {run_message}")
-            joined_df = empty_joined_odds_df()
-            picks_df = empty_final_picks_df()
-            post_df = empty_final_picks_df()
+            joined_df = _tag_workflow_frame(empty_joined_odds_df(), workflow)
+            picks_df = _tag_workflow_frame(empty_final_picks_df(), workflow)
+            post_df = _tag_workflow_frame(empty_final_picks_df(), workflow)
         else:
             validate_joined_odds_contract(joined_df)
 
             picks_df = build_picks_fn(joined_df)
+            picks_df = _tag_workflow_frame(picks_df, workflow)
             validate_final_picks_contract(picks_df)
 
             post_df = filter_postable_picks_fn(picks_df)
+            post_df = _tag_workflow_frame(post_df, workflow)
             validate_final_picks_contract(post_df)
     except requests.RequestException as exc:
         run_status = "degraded"
         run_message = (
-            "Live odds fetch failed; projections were saved but no edges or picks were generated. "
-            f"Reason: {exc.__class__.__name__}: {exc}"
+            f"Live odds fetch failed for {workflow.prop_type}; projections were saved but no edges "
+            f"or picks were generated. Reason: {exc.__class__.__name__}: {exc}"
         )
         print(f"WARNING: {run_message}")
-        joined_df = empty_joined_odds_df()
-        picks_df = empty_final_picks_df()
-        post_df = empty_final_picks_df()
+        joined_df = _tag_workflow_frame(empty_joined_odds_df(), workflow)
+        picks_df = _tag_workflow_frame(empty_final_picks_df(), workflow)
+        post_df = _tag_workflow_frame(empty_final_picks_df(), workflow)
+
+    return today_preds, joined_df, picks_df, post_df, run_status, run_message
+
+
+def run_daily_card(
+    *,
+    workflow: ModelingWorkflowSpec = MLB_PITCHER_STRIKEOUT_WORKFLOW,
+    workflows: list[ModelingWorkflowSpec] | None = None,
+    market: str | None = None,
+    build_picks_fn: BuildPicksFn | None = None,
+    filter_postable_picks_fn: FilterPostablePicksFn | None = None,
+) -> tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame, pd.DataFrame]:
+    ensure_output_dirs()
+
+    starters_df = get_today_starters_df()
+    validate_starters_contract(starters_df)
+
+    if workflows is not None:
+        selected_workflows = resolve_daily_card_workflows(workflows)
+    elif workflow is MLB_PITCHER_STRIKEOUT_WORKFLOW:
+        selected_workflows = resolve_daily_card_workflows()
+    else:
+        selected_workflows = [workflow]
+
+    today_preds_frames: list[pd.DataFrame] = []
+    joined_frames: list[pd.DataFrame] = []
+    picks_frames: list[pd.DataFrame] = []
+    post_frames: list[pd.DataFrame] = []
+    run_status = "success"
+    run_messages: list[str] = []
+
+    for active_workflow in selected_workflows:
+        (
+            workflow_today_preds,
+            workflow_joined_df,
+            workflow_picks_df,
+            workflow_post_df,
+            workflow_status,
+            workflow_message,
+        ) = run_workflow_daily_card(
+            starters_df=starters_df,
+            workflow=active_workflow,
+            market=market,
+            build_picks_fn=build_picks_fn,
+            filter_postable_picks_fn=filter_postable_picks_fn,
+        )
+        today_preds_frames.append(workflow_today_preds)
+        joined_frames.append(workflow_joined_df)
+        picks_frames.append(workflow_picks_df)
+        post_frames.append(workflow_post_df)
+
+        if workflow_status != "success":
+            run_status = "degraded"
+        if workflow_message:
+            run_messages.append(workflow_message)
+
+    today_preds = pd.concat(today_preds_frames, ignore_index=True) if today_preds_frames else pd.DataFrame()
+    joined_df = pd.concat(joined_frames, ignore_index=True) if joined_frames else empty_joined_odds_df()
+    picks_df = pd.concat(picks_frames, ignore_index=True) if picks_frames else empty_final_picks_df()
+    post_df = pd.concat(post_frames, ignore_index=True) if post_frames else empty_final_picks_df()
+    run_message = " ".join(run_messages) if run_messages else None
 
     save_outputs(
         starters_df=starters_df,
@@ -938,6 +1067,7 @@ if __name__ == "__main__":
         print(
             post_df[
                 [
+                    "prop_type",
                     "player_name",
                     "book",
                     "pick_side",

--- a/MLB/src/odds/create_picks.py
+++ b/MLB/src/odds/create_picks.py
@@ -123,11 +123,18 @@ def build_daily_picks(
     else:
         picks["player_name"] = picks["player_name_proj"]
 
+    if "prop_type" not in picks.columns:
+        if "market_key" in picks.columns:
+            picks["prop_type"] = picks["market_key"].fillna("").astype(str)
+        else:
+            picks["prop_type"] = ""
+
     picks = picks.drop(columns=["player_name_proj"])
     picks = picks.rename(columns={"bookmaker": "book"})
 
     preferred_cols = [
         "player_name",
+        "prop_type",
         PARTICIPANT_JOIN_KEY_COLUMN,
         "participant_id",
         "participant_source_id",
@@ -179,6 +186,13 @@ def filter_postable_picks(
     """
     if picks_df.empty:
         return picks_df.copy()
+
+    picks_df = picks_df.copy()
+    if "prop_type" not in picks_df.columns:
+        if "market_key" in picks_df.columns:
+            picks_df["prop_type"] = picks_df["market_key"].fillna("").astype(str)
+        else:
+            picks_df["prop_type"] = ""
 
     require_columns(picks_df, ["pick_type"], "picks_df")
 

--- a/MLB/src/pitcher_bb/feature_tomorrow.py
+++ b/MLB/src/pitcher_bb/feature_tomorrow.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+from common.contracts import require_columns, validate_pitcher_games_contract, validate_starters_contract
+from pitcher_k.feature_engineering import filter_starter_like_appearances, normalize_player_name, _safe_div
+
+from .config import BASE_FEATURES
+
+
+def build_tomorrow_features(
+    slate_df: pd.DataFrame,
+    pitcher_games: pd.DataFrame,
+    team_context: pd.DataFrame | None = None,
+    min_career_starts: int = 5,
+) -> pd.DataFrame:
+    slate_df = slate_df.copy()
+    pitcher_games = pitcher_games.copy()
+
+    validate_starters_contract(slate_df)
+    validate_pitcher_games_contract(pitcher_games)
+    require_columns(
+        pitcher_games,
+        [
+            "walks",
+            "pitches",
+            "batters_faced",
+            "avg_velo",
+            "avg_spin",
+        ],
+        "pitcher_games",
+    )
+    if team_context is not None:
+        require_columns(
+            team_context,
+            ["opponent_team", "opp_walks_per_game_last10", "opp_bb_rate_last10"],
+            "team_context",
+        )
+
+    slate_df["game_date"] = pd.to_datetime(slate_df["game_date"])
+    pitcher_games["game_date"] = pd.to_datetime(pitcher_games["game_date"])
+    pitcher_games = filter_starter_like_appearances(pitcher_games)
+
+    slate_df["player_name_norm"] = slate_df["player_name"].apply(normalize_player_name)
+    pitcher_games["player_name_norm"] = pitcher_games["player_name"].apply(normalize_player_name)
+    pitcher_games = pitcher_games.sort_values(["player_name_norm", "game_date", "game_pk"])
+
+    feature_rows = []
+    skipped_pitchers = 0
+
+    for _, row in slate_df.iterrows():
+        game_date = row["game_date"]
+        pitcher_id = row.get("pitcher", np.nan)
+        player_name_norm = row["player_name_norm"]
+
+        hist = pd.DataFrame()
+        if pd.notna(pitcher_id) and str(pitcher_id).strip() != "":
+            hist = pitcher_games[
+                (pitcher_games["pitcher"] == pitcher_id)
+                & (pitcher_games["game_date"] < game_date)
+            ].copy()
+
+        if hist.empty:
+            hist = pitcher_games[
+                (pitcher_games["player_name_norm"] == player_name_norm)
+                & (pitcher_games["game_date"] < game_date)
+            ].copy()
+
+        hist = hist.sort_values(["game_date", "game_pk"])
+        if len(hist) < min_career_starts:
+            skipped_pitchers += 1
+            continue
+
+        last3 = hist.tail(3)
+        last10 = hist.tail(10)
+        feature_row = row.to_dict()
+
+        feature_row["pitches_last3"] = last3["pitches"].mean()
+        feature_row["pitches_last10"] = last10["pitches"].mean()
+        feature_row["batters_faced_last3"] = last3["batters_faced"].mean()
+        feature_row["batters_faced_last10"] = last10["batters_faced"].mean()
+        feature_row["walks_last3"] = last3["walks"].mean()
+        feature_row["walks_last10"] = last10["walks"].mean()
+        feature_row["avg_velo_last3"] = last3["avg_velo"].mean()
+        feature_row["avg_spin_last3"] = last3["avg_spin"].mean()
+        feature_row["bb_per_pitch_last10"] = _safe_div(last10["walks"].sum(), last10["pitches"].sum())
+        feature_row["bb_rate_last10"] = _safe_div(last10["walks"].sum(), last10["batters_faced"].sum())
+        feature_row["walks_stddev_last10"] = last10["walks"].std(ddof=0)
+        feature_row["walks_p25_last10"] = last10["walks"].quantile(0.25)
+        feature_row["walks_p75_last10"] = last10["walks"].quantile(0.75)
+        feature_row["is_home"] = int(row["is_home"])
+        feature_row["opp_walks_per_game_last10"] = np.nan
+        feature_row["opp_bb_rate_last10"] = np.nan
+        feature_rows.append(feature_row)
+
+    features_df = pd.DataFrame(feature_rows)
+    if features_df.empty:
+        features_df.attrs["skipped_pitchers"] = skipped_pitchers
+        return features_df
+
+    if team_context is not None:
+        tc = team_context.copy().rename(columns={"opponent_team": "opponent"})
+        features_df = features_df.drop(
+            columns=["opp_walks_per_game_last10", "opp_bb_rate_last10"],
+            errors="ignore",
+        ).merge(
+            tc[["opponent", "opp_walks_per_game_last10", "opp_bb_rate_last10"]],
+            on="opponent",
+            how="left",
+        )
+
+    base_cols = [
+        "game_date",
+        "game_pk",
+        "pitcher",
+        "player_name",
+        "team",
+        "opponent",
+        "home_team",
+        "away_team",
+        "is_home",
+        "p_throws",
+    ]
+    feature_cols = [c for c in features_df.columns if c not in base_cols]
+    features_df = features_df[base_cols + feature_cols]
+    require_columns(
+        features_df,
+        [
+            "game_date",
+            "game_pk",
+            "pitcher",
+            "player_name",
+            "team",
+            "opponent",
+            "is_home",
+        ] + BASE_FEATURES,
+        "tomorrow_features_df",
+    )
+    features_df.attrs["skipped_pitchers"] = skipped_pitchers
+    return features_df

--- a/MLB/src/pitcher_bb/predict.py
+++ b/MLB/src/pitcher_bb/predict.py
@@ -1,0 +1,41 @@
+import pandas as pd
+import xgboost as xgb
+
+from .config import BASE_FEATURES
+
+
+def _add_projection_uncertainty(
+    pred_df: pd.DataFrame,
+    interval_config: dict | None = None,
+) -> pd.DataFrame:
+    pred_df = pred_df.copy()
+
+    if "walks_stddev_last10" not in pred_df.columns:
+        pred_df["std_dev"] = 0.0
+    else:
+        pred_df["std_dev"] = pred_df["walks_stddev_last10"].fillna(0.0).clip(lower=0.0)
+
+    interval_config = interval_config or {}
+    multiplier = float(interval_config.get("interval_multiplier", 1.0))
+    pred_df["raw_std_dev"] = pred_df["std_dev"]
+    pred_df["std_dev"] = pred_df["raw_std_dev"] * multiplier
+    pred_df["lower_bound"] = (pred_df["predicted_walks"] - pred_df["std_dev"]).clip(lower=0.0)
+    pred_df["upper_bound"] = pred_df["predicted_walks"] + pred_df["std_dev"]
+
+    if interval_config:
+        pred_df["interval_coverage_target"] = float(interval_config.get("nominal_coverage", 0.8))
+        pred_df["interval_multiplier"] = multiplier
+
+    return pred_df
+
+
+def predict_on_dataframe(
+    model,
+    df: pd.DataFrame,
+    features: list[str] = BASE_FEATURES,
+    interval_config: dict | None = None,
+) -> pd.DataFrame:
+    pred_df = df.copy()
+    dmatrix = xgb.DMatrix(pred_df[features], feature_names=features)
+    pred_df["predicted_walks"] = model.predict(dmatrix)
+    return _add_projection_uncertainty(pred_df, interval_config)

--- a/MLB/src/pitcher_bb/workflow.py
+++ b/MLB/src/pitcher_bb/workflow.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandas as pd
+import xgboost as xgb
+
+from common.contracts import validate_pitcher_games_contract
+from common.workflows import ModelingWorkflowSpec, ProjectionOddsJoinKeys, WorkflowArtifactSpec
+from odds.policy import DEFAULT_MLB_PITCHER_STRIKEOUT_POLICY, PostablePickLimits
+from pitcher_bb.config import PITCHER_BB_PROP_MARKET
+from pitcher_bb.feature_tomorrow import build_tomorrow_features
+from pitcher_bb.predict import predict_on_dataframe
+
+
+def load_pitcher_history_artifact(path: Path) -> pd.DataFrame:
+    pitcher_games = pd.read_csv(path)
+    pitcher_games["game_date"] = pd.to_datetime(pitcher_games["game_date"])
+    validate_pitcher_games_contract(pitcher_games)
+    return pitcher_games
+
+
+def load_xgboost_model_artifact(path: Path):
+    model = xgb.Booster()
+    model.load_model(str(path))
+    return model
+
+
+def build_mlb_pitcher_walk_features(
+    starters_df: pd.DataFrame,
+    pitcher_games: pd.DataFrame,
+) -> pd.DataFrame:
+    as_of_date = pd.to_datetime(starters_df["game_date"]).min()
+    team_context = build_team_context(pitcher_games, as_of_date=as_of_date)
+    return build_tomorrow_features(
+        slate_df=starters_df,
+        pitcher_games=pitcher_games,
+        team_context=team_context,
+    )
+
+
+def build_team_context(pitcher_games: pd.DataFrame, as_of_date: str | pd.Timestamp) -> pd.DataFrame:
+    df = pitcher_games.copy()
+    df["game_date"] = pd.to_datetime(df["game_date"])
+    as_of_date = pd.to_datetime(as_of_date)
+    df = df[df["game_date"] < as_of_date].copy()
+    df = df.sort_values(["opponent_team", "game_date", "game_pk"])
+    team_context = (
+        df.groupby("opponent_team", as_index=False)
+        .tail(1)[["opponent_team", "opp_walks_per_game_last10", "opp_bb_rate_last10"]]
+        .drop_duplicates(subset=["opponent_team"])
+        .reset_index(drop=True)
+    )
+    return team_context
+
+
+def apply_pitcher_bb_metadata_uncertainty(
+    today_preds: pd.DataFrame,
+    metadata: dict | None,
+) -> pd.DataFrame:
+    if today_preds.empty:
+        return today_preds
+
+    interval_config = (metadata or {}).get("uncertainty_model", {})
+    multiplier = float(interval_config.get("interval_multiplier", 1.0))
+    adjusted = today_preds.copy()
+    adjusted["raw_std_dev"] = pd.to_numeric(adjusted["std_dev"], errors="coerce").fillna(0.0).clip(lower=0.0)
+    adjusted["std_dev"] = adjusted["raw_std_dev"] * multiplier
+    adjusted["lower_bound"] = (adjusted["predicted_walks"] - adjusted["std_dev"]).clip(lower=0.0)
+    adjusted["upper_bound"] = adjusted["predicted_walks"] + adjusted["std_dev"]
+    if interval_config:
+        adjusted["interval_coverage_target"] = float(interval_config.get("nominal_coverage", 0.8))
+        adjusted["interval_multiplier"] = multiplier
+    return adjusted
+
+
+def adapt_pitcher_bb_predictions_for_daily_card(today_preds: pd.DataFrame) -> pd.DataFrame:
+    adapted = today_preds.copy()
+    adapted["predicted_strikeouts"] = adapted["predicted_walks"]
+    return adapted
+
+
+MLB_PITCHER_WALK_WORKFLOW = ModelingWorkflowSpec(
+    prop_type="pitcher_bb",
+    sport="MLB",
+    participant_key="player_name",
+    market_key=PITCHER_BB_PROP_MARKET,
+    artifacts=WorkflowArtifactSpec(
+        history_filename="pitcher_games.csv",
+        history_loader=load_pitcher_history_artifact,
+        model_filename="model.ubj",
+        model_loader=load_xgboost_model_artifact,
+        artifact_subdir="pitcher_bb",
+    ),
+    feature_builder=build_mlb_pitcher_walk_features,
+    predictor=predict_on_dataframe,
+    projection_odds_join_keys=ProjectionOddsJoinKeys(
+        projection="player_name_norm",
+        odds="player_name_norm",
+    ),
+    pick_ranking_policy=DEFAULT_MLB_PITCHER_STRIKEOUT_POLICY,
+    prediction_columns=(
+        "player_name",
+        "predicted_walks",
+        "lower_bound",
+        "upper_bound",
+        "std_dev",
+    ),
+    prediction_metadata_adjuster=apply_pitcher_bb_metadata_uncertainty,
+    prediction_output_adapter=adapt_pitcher_bb_predictions_for_daily_card,
+    postable_limits=PostablePickLimits(
+        max_official=3,
+        max_leans=1,
+    ),
+)

--- a/MLB/src/pitcher_k/workflow.py
+++ b/MLB/src/pitcher_k/workflow.py
@@ -60,6 +60,7 @@ def apply_pitcher_k_metadata_uncertainty(
 
 
 MLB_PITCHER_STRIKEOUT_WORKFLOW = ModelingWorkflowSpec(
+    prop_type="pitcher_k",
     sport="MLB",
     participant_key="player_name",
     market_key=PITCHER_K_PROP_MARKET,

--- a/MLB/tests/jobs/test_run_daily_card.py
+++ b/MLB/tests/jobs/test_run_daily_card.py
@@ -74,6 +74,7 @@ def test_run_daily_card_writes_outputs_with_mocked_dependencies(monkeypatch, tmp
     [
         {
             "player_name": "Jacob deGrom",
+            "prop_type": "pitcher_k",
             "team": "TEX",
             "opponent": "SEA",
             "predicted_strikeouts": 6.8,
@@ -188,6 +189,7 @@ def test_run_daily_card_writes_outputs_with_mocked_dependencies(monkeypatch, tmp
     )
     assert len(loaded_post) == 1
     assert loaded_post.loc[0, "player_name"] == "Jacob deGrom"
+    assert loaded_post.loc[0, "prop_type"] == "pitcher_k"
     assert loaded_post.loc[0, "pick_type"] == "official"
     assert len(loaded_history) == 1
     assert loaded_history.loc[0, "game_date"] == "2026-04-19"
@@ -332,8 +334,8 @@ def test_run_daily_card_allows_explicit_market_and_workflow_behavior(monkeypatch
         "odds_join_key": "player_name_norm",
         "sport": "MLB",
     }
-    pd.testing.assert_frame_equal(calls["build_picks_joined"], joined_df)
-    pd.testing.assert_frame_equal(calls["filter_postable_picks"], picks_df)
+    pd.testing.assert_frame_equal(calls["build_picks_joined"], joined_df.assign(prop_type="pitcher_k"))
+    pd.testing.assert_frame_equal(calls["filter_postable_picks"], picks_df.assign(prop_type="pitcher_k"))
 
 
 def test_run_daily_card_raises_when_today_predictions_are_empty(monkeypatch, tmp_path):
@@ -517,6 +519,7 @@ def test_run_daily_card_uses_workflow_spec_for_market_policy_and_limits(monkeypa
     calls: dict[str, object] = {}
 
     workflow = ModelingWorkflowSpec(
+        prop_type="custom_prop",
         sport="MLB",
         participant_key="player_name",
         market_key="workflow_market",
@@ -664,6 +667,7 @@ def test_run_daily_card_default_workflow_joins_live_odds_on_normalized_name(monk
         [
             {
                 "player_name": "Jacob deGrom",
+                "prop_type": "pitcher_k",
                 "book": "DraftKings",
                 "pick_side": "over",
                 "line": 5.5,
@@ -729,6 +733,131 @@ def test_run_daily_card_default_workflow_joins_live_odds_on_normalized_name(monk
     }
     assert calls["joined_preds"].loc[0, "pitcher"] == 1
     assert calls["joined_preds"].loc[0, "player_name_norm"] == "jacob degrom"
+    assert calls["joined_preds"].loc[0, "prop_type"] == "pitcher_k"
+
+
+def test_run_daily_card_combines_ready_workflow_outputs(monkeypatch, tmp_path):
+    starters_df = pd.DataFrame(
+        [
+            {
+                "game_date": "2026-04-19",
+                "game_pk": 123456,
+                "pitcher": 1,
+                "player_name": "Jacob deGrom",
+                "team": "TEX",
+                "opponent": "SEA",
+                "home_team": "TEX",
+                "away_team": "SEA",
+                "is_home": 1,
+                "p_throws": "R",
+            }
+        ]
+    )
+
+    monkeypatch.setattr(daily_card, "get_today_starters_df", lambda: starters_df)
+    monkeypatch.setattr(daily_card, "save_today_starters_csv", lambda df, output_dir=None, filename=None: tmp_path / "today_starters.csv")
+    monkeypatch.setattr(daily_card, "DATA_DIR", tmp_path / "data")
+    monkeypatch.setattr(daily_card, "OUTPUT_DIR", tmp_path / "data" / "outputs")
+    monkeypatch.setattr(daily_card, "PROJECTIONS_DIR", tmp_path / "data" / "outputs" / "projections")
+    monkeypatch.setattr(daily_card, "EDGES_DIR", tmp_path / "data" / "outputs" / "edges")
+    monkeypatch.setattr(daily_card, "PICKS_DIR", tmp_path / "data" / "outputs" / "picks")
+    monkeypatch.setattr(daily_card, "TRACKING_DIR", tmp_path / "data" / "tracking")
+    monkeypatch.setattr(
+        daily_card,
+        "OFFICIAL_PICKS_HISTORY_PATH",
+        tmp_path / "data" / "tracking" / "official_picks_history.csv",
+    )
+    monkeypatch.setattr(
+        daily_card,
+        "OFFICIAL_PICKS_GRADES_PATH",
+        tmp_path / "data" / "tracking" / "official_picks_profit_report.csv",
+    )
+    monkeypatch.setattr(
+        daily_card,
+        "OFFICIAL_PICKS_BOOK_SUMMARY_PATH",
+        tmp_path / "data" / "tracking" / "official_picks_profit_by_book.csv",
+    )
+    monkeypatch.setattr(
+        daily_card,
+        "OFFICIAL_PICKS_OVERALL_SUMMARY_PATH",
+        tmp_path / "data" / "tracking" / "official_picks_profit_summary.json",
+    )
+    monkeypatch.setattr(
+        daily_card,
+        "OFFICIAL_PICKS_SKIPPED_PATH",
+        tmp_path / "data" / "tracking" / "official_picks_profit_skipped.csv",
+    )
+
+    workflows = [
+        ModelingWorkflowSpec(
+            prop_type="pitcher_k",
+            sport="MLB",
+            participant_key="player_name",
+            market_key="pitcher_strikeouts",
+            artifacts=WorkflowArtifactSpec(
+                history_filename="k_history.csv",
+                history_loader=lambda path: pd.DataFrame(),
+                model_filename="k_model.ubj",
+                model_loader=lambda path: "unused",
+            ),
+            feature_builder=lambda starters, history: starters,
+            predictor=lambda model, features: features,
+            projection_odds_join_keys=ProjectionOddsJoinKeys(
+                projection="player_name_norm",
+                odds="player_name_norm",
+            ),
+            pick_ranking_policy=DEFAULT_MLB_PITCHER_STRIKEOUT_POLICY,
+            prediction_columns=("player_name", "predicted_strikeouts", "lower_bound", "upper_bound", "std_dev"),
+        ),
+        ModelingWorkflowSpec(
+            prop_type="pitcher_bb",
+            sport="MLB",
+            participant_key="player_name",
+            market_key="pitcher_walks",
+            artifacts=WorkflowArtifactSpec(
+                history_filename="bb_history.csv",
+                history_loader=lambda path: pd.DataFrame(),
+                model_filename="bb_model.ubj",
+                model_loader=lambda path: "unused",
+            ),
+            feature_builder=lambda starters, history: starters,
+            predictor=lambda model, features: features,
+            projection_odds_join_keys=ProjectionOddsJoinKeys(
+                projection="player_name_norm",
+                odds="player_name_norm",
+            ),
+            pick_ranking_policy=DEFAULT_MLB_PITCHER_STRIKEOUT_POLICY,
+            prediction_columns=("player_name", "predicted_strikeouts", "lower_bound", "upper_bound", "std_dev"),
+        ),
+    ]
+
+    def fake_run_workflow_daily_card(*, starters_df, workflow, market, build_picks_fn, filter_postable_picks_fn):
+        if workflow.prop_type == "pitcher_k":
+            return (
+                pd.DataFrame([{"player_name": "Jacob deGrom", "predicted_strikeouts": 6.8, "prop_type": "pitcher_k"}]),
+                pd.DataFrame([{"player_name_proj": "Jacob deGrom", "predicted_strikeouts": 6.8, "bookmaker": "DraftKings", "side": "Over", "line": 5.5, "price": -120, "prop_type": "pitcher_k"}]),
+                pd.DataFrame([{"player_name": "Jacob deGrom", "prop_type": "pitcher_k", "book": "DraftKings", "pick_side": "over", "line": 5.5, "price": -120, "edge": 1.3, "pick_type": "official", "implied_probability": 0.545, "value_score": 0.59, "confidence_tier": "medium"}]),
+                pd.DataFrame([{"player_name": "Jacob deGrom", "prop_type": "pitcher_k", "book": "DraftKings", "pick_side": "over", "line": 5.5, "price": -120, "edge": 1.3, "pick_type": "official", "implied_probability": 0.545, "value_score": 0.59, "confidence_tier": "medium"}]),
+                "success",
+                None,
+            )
+        return (
+            pd.DataFrame([{"player_name": "Tarik Skubal", "predicted_strikeouts": 2.2, "prop_type": "pitcher_bb"}]),
+            pd.DataFrame([{"player_name_proj": "Tarik Skubal", "predicted_strikeouts": 2.2, "bookmaker": "FanDuel", "side": "Under", "line": 2.5, "price": -105, "prop_type": "pitcher_bb"}]),
+            pd.DataFrame([{"player_name": "Tarik Skubal", "prop_type": "pitcher_bb", "book": "FanDuel", "pick_side": "under", "line": 2.5, "price": -105, "edge": 0.3, "pick_type": "lean", "implied_probability": 0.512, "value_score": 0.146, "confidence_tier": "low"}]),
+            pd.DataFrame([{"player_name": "Tarik Skubal", "prop_type": "pitcher_bb", "book": "FanDuel", "pick_side": "under", "line": 2.5, "price": -105, "edge": 0.3, "pick_type": "lean", "implied_probability": 0.512, "value_score": 0.146, "confidence_tier": "low"}]),
+            "success",
+            None,
+        )
+
+    monkeypatch.setattr(daily_card, "run_workflow_daily_card", fake_run_workflow_daily_card)
+
+    _, result_preds, result_picks, result_post = daily_card.run_daily_card(workflows=workflows)
+
+    assert set(result_preds["prop_type"]) == {"pitcher_k", "pitcher_bb"}
+    assert set(result_picks["prop_type"]) == {"pitcher_k", "pitcher_bb"}
+    assert set(result_post["prop_type"]) == {"pitcher_k", "pitcher_bb"}
+    assert list(result_post["player_name"]) == ["Jacob deGrom", "Tarik Skubal"]
 
 
 def test_persist_official_picks_history_is_idempotent_and_preserves_manual_results(tmp_path, monkeypatch):


### PR DESCRIPTION
What changed:


run_daily_card can now run one workflow or a list of workflows, aggregate their projections/picks/postable picks, and preserve the existing single-workflow behavior when workflow=... is passed.

Default daily-card behavior is readiness-gated: it will include pitcher walks only when the pitcher-BB workflow artifacts are actually present.

prop_type now flows through picks and saved history, so combined Ks/BB outputs stay distinguishable.

Pitcher walks got a real workflow module in workflow.py (line 1), plus predict.py (line 1) and feature_tomorrow.py (line 1), instead of wiring BB logic directly into the strikeout job.

Artifacts stay separated by workflow via artifact_subdir, so BB does not collide with strikeout models/artifacts.


Key files:


run_daily_card.py (line 1)

workflows.py (line 1)

create_picks.py (line 1)

contracts.py (line 1)


I also added combined-output regression coverage in test_run_daily_card.py (line 1), along with the prop_type contract updates.

Verification:

pytest tests/odds/test_create_picks.py tests/jobs/test_run_daily_card.py tests/pitcher_bb/test_config.py tests/pitcher_bb/test_pitcher_bb_feature_engineering.py tests/jobs/test_build_training_artifacts_pitcher_bb.py passed with 41 passed.