### PR TITLE
extending the shared quality-check system

### DIFF
--- a/MLB/src/jobs/run_daily_card.py
+++ b/MLB/src/jobs/run_daily_card.py
@@ -114,6 +114,12 @@ OFFICIAL_PICKS_PROFIT_SUMMARY_COLUMNS = [
     "roi",
 ]
 
+SUPPORTED_STATCAST_GRADING_MARKETS = {
+    "": "strikeouts",
+    "pitcher_strikeouts": "strikeouts",
+    "pitcher_walks": "walks",
+}
+
 BuildPicksFn = Callable[[pd.DataFrame], pd.DataFrame]
 FilterPostablePicksFn = Callable[[pd.DataFrame], pd.DataFrame]
 DEFAULT_DAILY_CARD_WORKFLOWS = [
@@ -266,9 +272,14 @@ def _yesterday_game_date() -> str:
     ).strftime("%Y-%m-%d")
 
 
-def _is_pitcher_strikeout_history_row(row: pd.Series) -> bool:
+def _supports_statcast_history_row(row: pd.Series) -> bool:
     market_key = str(row.get("market_key", "") or "").strip()
-    return market_key in {"", "pitcher_strikeouts"}
+    return market_key in SUPPORTED_STATCAST_GRADING_MARKETS
+
+
+def _statcast_result_column_for_row(row: pd.Series) -> str | None:
+    market_key = str(row.get("market_key", "") or "").strip()
+    return SUPPORTED_STATCAST_GRADING_MARKETS.get(market_key)
 
 
 def _grade_pick_result_from_actual(actual: float, line: float, pick_side: str) -> str:
@@ -303,6 +314,7 @@ def load_pitcher_results_from_statcast(game_date: str) -> pd.DataFrame:
                 "pitcher",
                 "player_name",
                 "strikeouts",
+                "walks",
             ]
         )
 
@@ -350,18 +362,21 @@ def apply_statcast_results_to_official_picks_history(
         source_id_col="pitcher" if "pitcher" in pitcher_results.columns else PARTICIPANT_SOURCE_ID_COLUMN,
         source_id_type="mlbam_player",
     )
+    for stat_column in ["strikeouts", "walks"]:
+        if stat_column not in pitcher_results.columns:
+            pitcher_results[stat_column] = pd.NA
 
     result_lookup = pitcher_results.drop_duplicates(
         subset=["game_date", PARTICIPANT_JOIN_KEY_COLUMN],
         keep="last",
     )[
-        ["game_date", PARTICIPANT_JOIN_KEY_COLUMN, "strikeouts"]
+        ["game_date", PARTICIPANT_JOIN_KEY_COLUMN, "strikeouts", "walks"]
     ].copy()
 
     pending_mask = (
         (working["pick_type"] == "official")
         & (working["game_date"].astype(str) == game_date)
-        & working.apply(_is_pitcher_strikeout_history_row, axis=1)
+        & working.apply(_supports_statcast_history_row, axis=1)
         & (
             working["actual_value"].astype(str).str.strip().eq("")
             | working["result"].astype(str).str.strip().eq("")
@@ -377,15 +392,23 @@ def apply_statcast_results_to_official_picks_history(
         on=["game_date", PARTICIPANT_JOIN_KEY_COLUMN],
         how="left",
     )
-    resolved_mask = pending["strikeouts"].notna()
+    pending["statcast_result_column"] = pending.apply(_statcast_result_column_for_row, axis=1)
+    pending["actual_stat_value"] = pending.apply(
+        lambda row: row.get(str(row["statcast_result_column"]), pd.NA)
+        if row["statcast_result_column"]
+        else pd.NA,
+        axis=1,
+    )
+    resolved_mask = pd.to_numeric(pending["actual_stat_value"], errors="coerce").notna()
     if not resolved_mask.any():
         return working[OFFICIAL_PICKS_HISTORY_COLUMNS].copy()
 
-    pending.loc[resolved_mask, "actual_value"] = pending.loc[resolved_mask, "strikeouts"].apply(_format_stat_value)
-    pending.loc[resolved_mask, "actual_strikeouts"] = pending.loc[resolved_mask, "actual_value"]
+    pending.loc[resolved_mask, "actual_value"] = pending.loc[resolved_mask, "actual_stat_value"].apply(_format_stat_value)
+    strikeout_mask = resolved_mask & pending["statcast_result_column"].eq("strikeouts")
+    pending.loc[strikeout_mask, "actual_strikeouts"] = pending.loc[strikeout_mask, "actual_value"]
     pending.loc[resolved_mask, "result"] = pending.loc[resolved_mask].apply(
         lambda row: _grade_pick_result_from_actual(
-            actual=float(row["strikeouts"]),
+            actual=float(row["actual_stat_value"]),
             line=float(row["line"]),
             pick_side=str(row["pick_side"]),
         ),
@@ -411,7 +434,7 @@ def grade_official_picks_from_statcast(
     pending_mask = (
         (history_df["pick_type"] == "official")
         & (history_df["game_date"].astype(str) == target_date)
-        & history_df.apply(_is_pitcher_strikeout_history_row, axis=1)
+        & history_df.apply(_supports_statcast_history_row, axis=1)
         & (
             history_df["actual_value"].astype(str).str.strip().eq("")
             | history_df["result"].astype(str).str.strip().eq("")

--- a/MLB/src/odds/backtest.py
+++ b/MLB/src/odds/backtest.py
@@ -45,6 +45,19 @@ def _line_band(line: float) -> str:
     return "7.5+"
 
 
+def _edge_bucket(edge: float) -> str:
+    if pd.isna(edge):
+        return "unknown"
+    abs_edge = abs(float(edge))
+    if abs_edge < 0.5:
+        return "<0.5"
+    if abs_edge < 1.0:
+        return "0.5-1.0"
+    if abs_edge < 1.5:
+        return "1.0-1.5"
+    return "1.5+"
+
+
 def _grade_pick_outcome(actual: float, line: float, pick_side: str) -> str:
     if pick_side == "over":
         if actual > line:
@@ -116,6 +129,7 @@ def grade_pick_backtest(
         axis=1,
     )
     graded["line_band"] = graded["line"].apply(_line_band)
+    graded["edge_bucket"] = graded["edge"].apply(_edge_bucket)
     return graded
 
 
@@ -205,6 +219,7 @@ def run_pick_backtest(
             "by_confidence_tier": [],
             "by_book": [],
             "by_line_band": [],
+            "by_edge_bucket": [],
             "by_pick_side": [],
             "graded_picks": pd.DataFrame(),
         }
@@ -222,6 +237,7 @@ def run_pick_backtest(
             "by_confidence_tier": [],
             "by_book": [],
             "by_line_band": [],
+            "by_edge_bucket": [],
             "by_pick_side": [],
             "graded_picks": picks,
         }
@@ -234,6 +250,7 @@ def run_pick_backtest(
         "by_confidence_tier": _summarize_groups(graded, "confidence_tier"),
         "by_book": _summarize_groups(graded, "book"),
         "by_line_band": _summarize_groups(graded, "line_band"),
+        "by_edge_bucket": _summarize_groups(graded, "edge_bucket"),
         "by_pick_side": _summarize_groups(graded, "pick_side"),
         "graded_picks": graded,
     }
@@ -289,6 +306,7 @@ def run_historical_workflow_backtest(
             "by_confidence_tier": [],
             "by_book": [],
             "by_line_band": [],
+            "by_edge_bucket": [],
             "by_pick_side": [],
             "graded_picks": pd.DataFrame(),
         }

--- a/MLB/src/odds/create_picks.py
+++ b/MLB/src/odds/create_picks.py
@@ -148,6 +148,7 @@ def build_daily_picks(
     picks["pick_type"] = picks["edge"].apply(policy.classify_pick_type)
     picks["value_score"] = picks["edge"].abs() * (1 - picks["implied_probability"])
     picks["confidence_tier"] = picks["value_score"].apply(policy.classify_confidence_tier)
+    picks["risk_tier"] = picks["implied_probability"].apply(policy.classify_risk_tier)
 
     if "player_name" in picks.columns:
         picks["player_name"] = picks["player_name_proj"].combine_first(picks["player_name"])
@@ -195,6 +196,7 @@ def build_daily_picks(
         "implied_probability",
         "value_score",
         "confidence_tier",
+        "risk_tier",
         "pick_type",
     ]
 

--- a/MLB/src/odds/policy.py
+++ b/MLB/src/odds/policy.py
@@ -27,6 +27,11 @@ class PickRankingPolicy:
     market_ranking_rules: tuple[MarketRankingRule, ...]
     edge_tie_preference: str
     pick_type_order: tuple[str, ...]
+    risk_tier_thresholds: tuple[tuple[str, float], ...] = (
+        ("low", 0.58),
+        ("medium", 0.50),
+    )
+    risk_default_tier: str = "high"
     postable_limits: PostablePickLimits = field(default_factory=PostablePickLimits)
 
     def classify_pick_type(self, edge: float) -> str:
@@ -43,6 +48,12 @@ class PickRankingPolicy:
             if value_score >= threshold:
                 return tier_name
         return self.confidence_default_tier
+
+    def classify_risk_tier(self, implied_probability: float) -> str:
+        for tier_name, threshold in self.risk_tier_thresholds:
+            if implied_probability >= threshold:
+                return tier_name
+        return self.risk_default_tier
 
     def select_best_market(self, player_df: pd.DataFrame, side: str) -> pd.Series:
         rule = self._market_rule_for_side(side)
@@ -150,6 +161,11 @@ DEFAULT_MLB_PITCHER_STRIKEOUT_POLICY = PickRankingPolicy(
         ("low", 0.15),
     ),
     confidence_default_tier="thin",
+    risk_tier_thresholds=(
+        ("low", 0.58),
+        ("medium", 0.50),
+    ),
+    risk_default_tier="high",
     market_ranking_rules=(
         MarketRankingRule(
             side="over",

--- a/MLB/tests/jobs/test_run_daily_card.py
+++ b/MLB/tests/jobs/test_run_daily_card.py
@@ -1810,6 +1810,66 @@ def test_apply_statcast_results_to_official_picks_history_updates_yesterday_pick
     assert updated.loc[0, "result"] == "W"
 
 
+def test_apply_statcast_results_to_official_picks_history_updates_pitcher_walk_results():
+    history_df = pd.DataFrame(
+        [
+            {
+                "pick_key": "2026-05-06|pitcher-walks-a",
+                "game_date": "2026-05-06",
+                "player_name": "Pitcher Walks A",
+                "participant_join_key": "mlbam_player:303",
+                "participant_id": "mlbam_player:303",
+                "participant_source_id": "303",
+                "participant_source_id_type": "mlbam_player",
+                "participant_name_norm": "pitcher walks a",
+                "sport": "MLB",
+                "market_key": "pitcher_walks",
+                "market_family": "player_prop",
+                "team": "AAA",
+                "opponent": "BBB",
+                "book": "FanDuel",
+                "bookmaker_key": "fanduel",
+                "event_id": "evt_walks",
+                "odds": "-105",
+                "price": -105,
+                "pick_side": "under",
+                "line": 2.5,
+                "market_selection_key": "MLB|pitcher_walks|mlbam_player:303|under|2.5",
+                "market_offer_key": "MLB|pitcher_walks|mlbam_player:303|under|2.5|fanduel",
+                "predicted_value": 2.2,
+                "edge": 0.3,
+                "confidence_tier": "low",
+                "pick_type": "official",
+                "result": "",
+                "actual_value": "",
+                "actual_strikeouts": "",
+                "record_source": "run_daily_card",
+            }
+        ]
+    )
+    pitcher_results_df = pd.DataFrame(
+        [
+            {
+                "game_date": "2026-05-06",
+                "pitcher": 303,
+                "player_name": "Pitcher Walks A",
+                "strikeouts": 7,
+                "walks": 1,
+            }
+        ]
+    )
+
+    updated = daily_card.apply_statcast_results_to_official_picks_history(
+        history_df,
+        pitcher_results_df,
+        game_date="2026-05-06",
+    )
+
+    assert updated.loc[0, "actual_value"] == "1"
+    assert updated.loc[0, "actual_strikeouts"] == ""
+    assert updated.loc[0, "result"] == "W"
+
+
 def test_grade_official_picks_from_statcast_persists_updates_and_profit_reports(tmp_path, monkeypatch):
     tracking_dir = tmp_path / "data" / "tracking"
     tracking_dir.mkdir(parents=True, exist_ok=True)
@@ -1887,3 +1947,84 @@ def test_grade_official_picks_from_statcast_persists_updates_and_profit_reports(
     assert loaded_history.loc[0, "result"] == "L"
     assert grades_df.loc[0, "result"] == "L"
     assert summary_payload["losses"] == 1
+
+
+def test_grade_official_picks_from_statcast_persists_pitcher_walk_updates(tmp_path, monkeypatch):
+    tracking_dir = tmp_path / "data" / "tracking"
+    tracking_dir.mkdir(parents=True, exist_ok=True)
+    history_path = tracking_dir / "official_picks_history.csv"
+    grades_path = tracking_dir / "official_picks_profit_report.csv"
+    by_book_path = tracking_dir / "official_picks_profit_by_book.csv"
+    summary_path = tracking_dir / "official_picks_profit_summary.json"
+    skipped_path = tracking_dir / "official_picks_profit_skipped.csv"
+
+    history_df = pd.DataFrame(
+        [
+            {
+                "pick_key": "2026-05-06|pitcher-walks-a",
+                "game_date": "2026-05-06",
+                "player_name": "Pitcher Walks A",
+                "participant_join_key": "mlbam_player:303",
+                "participant_id": "mlbam_player:303",
+                "participant_source_id": "303",
+                "participant_source_id_type": "mlbam_player",
+                "participant_name_norm": "pitcher walks a",
+                "sport": "MLB",
+                "market_key": "pitcher_walks",
+                "market_family": "player_prop",
+                "team": "AAA",
+                "opponent": "BBB",
+                "book": "FanDuel",
+                "bookmaker_key": "fanduel",
+                "event_id": "evt_walks",
+                "odds": "-105",
+                "price": -105,
+                "pick_side": "under",
+                "line": 2.5,
+                "market_selection_key": "MLB|pitcher_walks|mlbam_player:303|under|2.5",
+                "market_offer_key": "MLB|pitcher_walks|mlbam_player:303|under|2.5|fanduel",
+                "predicted_value": 2.2,
+                "edge": 0.3,
+                "confidence_tier": "low",
+                "pick_type": "official",
+                "result": "",
+                "actual_value": "",
+                "actual_strikeouts": "",
+                "record_source": "run_daily_card",
+            }
+        ]
+    )
+    history_df.to_csv(history_path, index=False)
+
+    monkeypatch.setattr(daily_card, "OFFICIAL_PICKS_HISTORY_PATH", history_path)
+    monkeypatch.setattr(daily_card, "OFFICIAL_PICKS_GRADES_PATH", grades_path)
+    monkeypatch.setattr(daily_card, "OFFICIAL_PICKS_BOOK_SUMMARY_PATH", by_book_path)
+    monkeypatch.setattr(daily_card, "OFFICIAL_PICKS_OVERALL_SUMMARY_PATH", summary_path)
+    monkeypatch.setattr(daily_card, "OFFICIAL_PICKS_SKIPPED_PATH", skipped_path)
+    monkeypatch.setattr(
+        daily_card,
+        "load_pitcher_results_from_statcast",
+        lambda game_date: pd.DataFrame(
+            [
+                {
+                    "game_date": game_date,
+                    "pitcher": 303,
+                    "player_name": "Pitcher Walks A",
+                    "strikeouts": 7,
+                    "walks": 1,
+                }
+            ]
+        ),
+    )
+
+    result = daily_card.grade_official_picks_from_statcast(game_date="2026-05-06")
+
+    loaded_history = pd.read_csv(history_path, keep_default_na=False)
+    grades_df = pd.read_csv(grades_path)
+    summary_payload = daily_card.json.loads(summary_path.read_text(encoding="utf-8"))
+
+    assert result["updated_rows"] == 1
+    assert str(loaded_history.loc[0, "actual_value"]) == "1"
+    assert loaded_history.loc[0, "result"] == "W"
+    assert grades_df.loc[0, "result"] == "W"
+    assert summary_payload["wins"] == 1

--- a/MLB/tests/odds/test_backtest.py
+++ b/MLB/tests/odds/test_backtest.py
@@ -70,6 +70,11 @@ def test_run_pick_backtest_summarizes_workflow_by_betting_segments():
     assert by_band["4.5-5.5"]["picks"] == 1
     assert by_band["<=4.5"]["picks"] == 1
 
+    by_edge_bucket = {row["edge_bucket"]: row for row in backtest["by_edge_bucket"]}
+    assert by_edge_bucket["1.0-1.5"]["picks"] == 1
+    assert by_edge_bucket["0.5-1.0"]["picks"] == 1
+    assert by_edge_bucket["<0.5"]["picks"] == 1
+
     graded = backtest["graded_picks"]
     assert set(graded["outcome"]) == {"win", "loss"}
 
@@ -139,3 +144,46 @@ def test_run_historical_workflow_backtest_uses_native_lines_artifact_rows():
     assert backtest["available"] is True
     assert backtest["overall"][0]["picks"] == 2
     assert backtest["overall"][0]["wins"] == 2
+
+
+def test_run_pick_backtest_supports_pitcher_walks_and_edge_buckets():
+    joined_df = pd.DataFrame(
+        [
+            {
+                "player_name_proj": "Tarik Skubal",
+                "market_key": "pitcher_walks",
+                "predicted_walks": 2.2,
+                "predicted_value": 2.2,
+                "bookmaker": "FanDuel",
+                "side": "Under",
+                "line": 2.5,
+                "price": -105,
+                "actual_walks": 1,
+                "actual_value": 1,
+            },
+            {
+                "player_name_proj": "Chris Sale",
+                "market_key": "pitcher_walks",
+                "predicted_walks": 2.1,
+                "predicted_value": 2.1,
+                "bookmaker": "DraftKings",
+                "side": "Over",
+                "line": 1.5,
+                "price": 110,
+                "actual_walks": 3,
+                "actual_value": 3,
+            },
+        ]
+    )
+
+    backtest = run_pick_backtest(
+        joined_df,
+        prediction_column="predicted_value",
+        actual_column="actual_value",
+    )
+
+    assert backtest["available"] is True
+    assert backtest["overall"][0]["picks"] == 2
+    assert backtest["overall"][0]["wins"] == 2
+    by_edge_bucket = {row["edge_bucket"]: row for row in backtest["by_edge_bucket"]}
+    assert set(by_edge_bucket) == {"0.5-1.0", "<0.5"}

--- a/MLB/tests/odds/test_create_picks.py
+++ b/MLB/tests/odds/test_create_picks.py
@@ -348,6 +348,7 @@ def test_build_daily_picks_adds_implied_probability_value_score_and_confidence_t
     assert picks.loc[0, "implied_probability"] == pytest.approx(expected_implied_probability)
     assert picks.loc[0, "value_score"] == pytest.approx(expected_value_score)
     assert picks.loc[0, "confidence_tier"] in {"high", "medium", "low", "thin"}
+    assert picks.loc[0, "risk_tier"] in {"low", "medium", "high"}
 
 
 def test_build_daily_picks_preserves_projection_uncertainty_fields():
@@ -433,3 +434,32 @@ def test_filter_postable_picks_preserves_value_fields():
     assert "implied_probability" in postable.columns
     assert "value_score" in postable.columns
     assert "confidence_tier" in postable.columns
+
+
+def test_build_daily_picks_supports_pitcher_walks_value_and_risk_fields():
+    joined_df = pd.DataFrame(
+        [
+            {
+                "player_name_proj": "Tarik Skubal",
+                "team": "DET",
+                "opponent": "CLE",
+                "market_key": "pitcher_walks",
+                "predicted_walks": 2.2,
+                "predicted_value": 2.2,
+                "bookmaker": "FanDuel",
+                "side": "Under",
+                "line": 2.5,
+                "price": -105,
+            }
+        ]
+    )
+
+    picks = build_daily_picks(joined_df, prediction_column="predicted_value")
+
+    assert picks.loc[0, "player_name"] == "Tarik Skubal"
+    assert picks.loc[0, "pick_side"] == "under"
+    assert picks.loc[0, "edge"] == pytest.approx(0.3)
+    assert picks.loc[0, "implied_probability"] == pytest.approx(105 / 205)
+    assert picks.loc[0, "value_score"] == pytest.approx(0.3 * (1 - (105 / 205)))
+    assert picks.loc[0, "confidence_tier"] == "thin"
+    assert picks.loc[0, "risk_tier"] == "medium"


### PR DESCRIPTION
What changed:


policy.py: added shared risk_tier classification, with backward-compatible defaults.

create_picks.py: pitcher walks now get the same implied_probability, value_score, confidence_tier, and new risk_tier fields as strikeouts.

backtest.py: added shared hit-rate tracking by edge_bucket, so strategy-quality summaries now include edge-bucket win/loss performance for any prop.

run_daily_card.py: historical grading is now market-aware. Official picks for pitcher_walks can be auto-graded from Statcast walks just like strikeout picks are graded from Statcast strikeouts.


I also added regression coverage for the new behavior:


test_create_picks.py: pitcher-walk value/confidence/risk fields

test_backtest.py: edge-bucket summaries and pitcher-walk backtests

test_run_daily_card.py: pitcher-walk historical grading from Statcast