### PR TITLE
canonical evaluation_summary.json

### DIFF
--- a/MLB/src/common/evaluation_artifacts.py
+++ b/MLB/src/common/evaluation_artifacts.py
@@ -1,0 +1,148 @@
+from __future__ import annotations
+
+from copy import deepcopy
+
+
+def _listify_limitations(*values: object) -> list[str]:
+    limitations: list[str] = []
+    for value in values:
+        if value is None:
+            continue
+        if isinstance(value, str):
+            stripped = value.strip()
+            if stripped:
+                limitations.append(stripped)
+            continue
+        if isinstance(value, list):
+            for item in value:
+                if isinstance(item, str) and item.strip():
+                    limitations.append(item.strip())
+    return limitations
+
+
+def _build_holdout_sections(metadata: dict) -> list[dict]:
+    training_window = metadata.get("training_window", {})
+    evaluation_metrics = metadata.get("evaluation_metrics", {})
+    uncertainty_model = metadata.get("uncertainty_model", {})
+    sample_sizes = evaluation_metrics.get("sample_sizes", {})
+
+    base_context = {
+        "mode": "fixed_holdout",
+        "sample_size": {
+            "rows": sample_sizes.get("test_rows", training_window.get("test_rows")),
+            "train_rows": sample_sizes.get("train_rows", training_window.get("train_rows")),
+        },
+        "date_range": training_window.get("test_game_date_range", {"start": None, "end": None}),
+    }
+
+    return [
+        {
+            "name": "holdout_regression",
+            **deepcopy(base_context),
+            "metrics": deepcopy(evaluation_metrics.get("regression", {})),
+            "limitations": _listify_limitations(
+                "Uses one fixed time-based holdout split defined by train_split_date.",
+                "Measures prediction error only; it does not reflect pick-selection or bankroll outcomes.",
+            ),
+        },
+        {
+            "name": "holdout_uncertainty",
+            **deepcopy(base_context),
+            "metrics": deepcopy(evaluation_metrics.get("uncertainty", {})),
+            "calibration": deepcopy(uncertainty_model),
+            "limitations": _listify_limitations(
+                uncertainty_model.get("documented_interpretation"),
+                "Coverage is evaluated on the same fixed holdout window and depends on the recent-stddev signal being present.",
+            ),
+        },
+        {
+            "name": "holdout_bucketed_error",
+            **deepcopy(base_context),
+            "metrics": deepcopy(evaluation_metrics.get("bucketed_error", {})),
+            "limitations": _listify_limitations(
+                "Bucket summaries are descriptive slices of the fixed holdout set and can be noisy in small buckets.",
+            ),
+        },
+    ]
+
+
+def _build_workflow_backtest_section(metadata: dict) -> dict:
+    training_window = metadata.get("training_window", {})
+    workflow_backtest = deepcopy(metadata.get("evaluation_metrics", {}).get("workflow_backtest", {}))
+    historical_lines_artifact = metadata.get("historical_lines_artifact", {})
+    overall_records = workflow_backtest.get("overall") or []
+    overall_summary = overall_records[0] if overall_records else {}
+
+    return {
+        "name": "workflow_backtest",
+        "mode": "fixed_holdout_workflow_backtest",
+        "available": bool(workflow_backtest.get("available", False)),
+        "sample_size": {
+            "holdout_rows": metadata.get("evaluation_metrics", {}).get("sample_sizes", {}).get(
+                "test_rows",
+                training_window.get("test_rows"),
+            ),
+            "graded_pick_rows": workflow_backtest.get("graded_pick_rows", 0),
+            "picks": overall_summary.get("picks"),
+            "decisions": overall_summary.get("decisions"),
+        },
+        "date_range": training_window.get("test_game_date_range", {"start": None, "end": None}),
+        "metrics": workflow_backtest,
+        "limitations": _listify_limitations(
+            historical_lines_artifact.get("limitations"),
+            workflow_backtest.get("reason"),
+            "Runs the live pick-selection workflow on holdout-era historical lines rather than a rolling retrain backtest.",
+        ),
+    }
+
+
+def _build_tracked_performance_section() -> dict:
+    return {
+        "name": "tracked_performance",
+        "mode": "all_time_tracked_performance",
+        "available": False,
+        "included_in_reproducible_artifact": False,
+        "metrics": {},
+        "limitations": [
+            "Excluded from this reproducible artifact build because tracked performance depends on operational pick history and grading files, not just training inputs.",
+        ],
+    }
+
+
+def build_evaluation_summary(
+    metadata: dict,
+    *,
+    workflow_name: str,
+    artifact_family: str,
+) -> dict:
+    training_window = metadata.get("training_window", {})
+
+    sections = [
+        *_build_holdout_sections(metadata),
+        _build_workflow_backtest_section(metadata),
+        _build_tracked_performance_section(),
+    ]
+
+    return {
+        "artifact_type": "evaluation_summary",
+        "artifact_version": 1,
+        "workflow_name": workflow_name,
+        "artifact_family": artifact_family,
+        "target": metadata.get("target"),
+        "train_split_date": training_window.get("train_split_date"),
+        "training_window": {
+            "raw_statcast_start": training_window.get("raw_statcast_start"),
+            "raw_statcast_end": training_window.get("raw_statcast_end"),
+            "train_game_date_range": deepcopy(
+                training_window.get("train_game_date_range", {"start": None, "end": None})
+            ),
+            "test_game_date_range": deepcopy(
+                training_window.get("test_game_date_range", {"start": None, "end": None})
+            ),
+        },
+        "sections": sections,
+        "limitations": _listify_limitations(
+            "This artifact is reproducible from the training-artifact build and intentionally separates model evaluation from daily card outputs.",
+            "Fixed-holdout sections use the train/test split defined during model training.",
+        ),
+    }

--- a/MLB/src/jobs/build_training_artifacts.py
+++ b/MLB/src/jobs/build_training_artifacts.py
@@ -9,6 +9,7 @@ from pathlib import Path
 import pandas as pd
 
 from common.contracts import validate_pitcher_games_contract, require_columns
+from common.evaluation_artifacts import build_evaluation_summary
 from odds.backtest import run_historical_workflow_backtest, summarize_backtest_for_metadata
 from odds.historical_lines import build_historical_lines_artifact_df, empty_historical_lines_df
 from pitcher_k.evaluate import (
@@ -53,6 +54,7 @@ PITCHER_GAMES_FILENAME = "pitcher_games.csv"
 MODEL_DF_FILENAME = "model_df.csv"
 HISTORICAL_LINES_FILENAME = "historical_lines.csv"
 METADATA_FILENAME = "metadata.json"
+EVALUATION_SUMMARY_FILENAME = "evaluation_summary.json"
 RAW_HISTORICAL_LINES_DIR = DATA_DIR / "raw" / "historical_lines"
 
 
@@ -69,6 +71,7 @@ def artifact_paths(base_dir: Path) -> dict[str, Path]:
         "model_df": base_dir / MODEL_DF_FILENAME,
         "historical_lines": base_dir / HISTORICAL_LINES_FILENAME,
         "metadata": base_dir / METADATA_FILENAME,
+        "evaluation_summary": base_dir / EVALUATION_SUMMARY_FILENAME,
     }
 
 
@@ -293,6 +296,7 @@ def save_artifacts_to_dir(
     historical_lines_df: pd.DataFrame,
     model,
     metadata: dict,
+    evaluation_summary: dict,
 ) -> dict[str, Path]:
     output_dir.mkdir(parents=True, exist_ok=True)
     paths = artifact_paths(output_dir)
@@ -302,6 +306,10 @@ def save_artifacts_to_dir(
     historical_lines_df.to_csv(paths["historical_lines"], index=False)
     model.save_model(str(paths["model"]))
     paths["metadata"].write_text(json.dumps(metadata, indent=2), encoding="utf-8")
+    paths["evaluation_summary"].write_text(
+        json.dumps(evaluation_summary, indent=2),
+        encoding="utf-8",
+    )
 
     return paths
 
@@ -335,6 +343,11 @@ def build_training_artifacts() -> tuple[pd.DataFrame, pd.DataFrame, Path, Path]:
         pitcher_games,
         historical_lines_df=historical_lines_df,
     )
+    evaluation_summary = build_evaluation_summary(
+        metadata,
+        workflow_name="mlb_pitcher_strikeouts",
+        artifact_family="default",
+    )
 
     staging_paths = save_artifacts_to_dir(
         output_dir=STAGING_DIR,
@@ -343,6 +356,7 @@ def build_training_artifacts() -> tuple[pd.DataFrame, pd.DataFrame, Path, Path]:
         historical_lines_df=historical_lines_df,
         model=model,
         metadata=metadata,
+        evaluation_summary=evaluation_summary,
     )
     validate_saved_artifacts(staging_paths)
 

--- a/MLB/src/jobs/build_training_artifacts_pitcher_bb.py
+++ b/MLB/src/jobs/build_training_artifacts_pitcher_bb.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import pandas as pd
 
 from common.contracts import require_columns, validate_pitcher_games_contract
+from common.evaluation_artifacts import build_evaluation_summary
 from odds.historical_lines import build_historical_lines_artifact_df
 from pitcher_bb.config import (
     BASE_FEATURES,
@@ -38,6 +39,7 @@ PITCHER_GAMES_FILENAME = "pitcher_games.csv"
 MODEL_DF_FILENAME = "model_df.csv"
 HISTORICAL_LINES_FILENAME = "historical_lines.csv"
 METADATA_FILENAME = "metadata.json"
+EVALUATION_SUMMARY_FILENAME = "evaluation_summary.json"
 RAW_HISTORICAL_LINES_DIR = DATA_DIR / "raw" / "historical_lines"
 UNCERTAINTY_STDDEV_COLUMN = "walks_stddev_last10"
 
@@ -55,6 +57,7 @@ def artifact_paths(base_dir: Path) -> dict[str, Path]:
         "model_df": base_dir / MODEL_DF_FILENAME,
         "historical_lines": base_dir / HISTORICAL_LINES_FILENAME,
         "metadata": base_dir / METADATA_FILENAME,
+        "evaluation_summary": base_dir / EVALUATION_SUMMARY_FILENAME,
     }
 
 
@@ -265,6 +268,7 @@ def save_artifacts_to_dir(
     historical_lines_df: pd.DataFrame,
     model,
     metadata: dict,
+    evaluation_summary: dict,
 ) -> dict[str, Path]:
     output_dir.mkdir(parents=True, exist_ok=True)
     paths = artifact_paths(output_dir)
@@ -273,6 +277,10 @@ def save_artifacts_to_dir(
     historical_lines_df.to_csv(paths["historical_lines"], index=False)
     model.save_model(str(paths["model"]))
     paths["metadata"].write_text(json.dumps(metadata, indent=2), encoding="utf-8")
+    paths["evaluation_summary"].write_text(
+        json.dumps(evaluation_summary, indent=2),
+        encoding="utf-8",
+    )
     return paths
 
 
@@ -288,6 +296,11 @@ def build_training_artifacts() -> dict[str, Path]:
         pitcher_games,
         historical_lines_df=historical_lines_df,
     )
+    evaluation_summary = build_evaluation_summary(
+        metadata,
+        workflow_name="mlb_pitcher_walks",
+        artifact_family="pitcher_bb",
+    )
 
     promote_latest_to_previous()
     save_artifacts_to_dir(
@@ -297,6 +310,7 @@ def build_training_artifacts() -> dict[str, Path]:
         historical_lines_df=historical_lines_df,
         model=model,
         metadata=metadata,
+        evaluation_summary=evaluation_summary,
     )
     promote_staging_to_latest()
     return artifact_paths(LATEST_DIR)

--- a/MLB/tests/jobs/test_build_training_artifacts.py
+++ b/MLB/tests/jobs/test_build_training_artifacts.py
@@ -43,6 +43,11 @@ def test_save_artifacts_to_dir_writes_metadata_json(tmp_path):
         "training_window": {"train_split_date": "2025-08-01"},
         "evaluation_metrics": {"mae": 0.91},
     }
+    evaluation_summary = {
+        "artifact_type": "evaluation_summary",
+        "artifact_version": 1,
+        "sections": [],
+    }
 
     paths = training_job.save_artifacts_to_dir(
         output_dir=output_dir,
@@ -51,12 +56,16 @@ def test_save_artifacts_to_dir_writes_metadata_json(tmp_path):
         historical_lines_df=historical_lines_df,
         model=FakeModel(),
         metadata=metadata,
+        evaluation_summary=evaluation_summary,
     )
 
     saved_metadata = json.loads(paths["metadata"].read_text(encoding="utf-8"))
+    saved_evaluation_summary = json.loads(paths["evaluation_summary"].read_text(encoding="utf-8"))
 
     assert paths["metadata"].exists()
+    assert paths["evaluation_summary"].exists()
     assert saved_metadata == metadata
+    assert saved_evaluation_summary == evaluation_summary
 
 
 def test_promote_latest_to_previous_preserves_matching_metadata(tmp_path, monkeypatch):
@@ -77,6 +86,10 @@ def test_promote_latest_to_previous_preserves_matching_metadata(tmp_path, monkey
         '{"target": "strikeouts", "training_window": {"train_split_date": "2025-08-01"}}',
         encoding="utf-8",
     )
+    latest_paths["evaluation_summary"].write_text(
+        '{"artifact_type": "evaluation_summary", "artifact_version": 1, "sections": []}',
+        encoding="utf-8",
+    )
 
     monkeypatch.setattr(training_job, "LATEST_DIR", latest_dir)
     monkeypatch.setattr(training_job, "PREVIOUS_DIR", previous_dir)
@@ -85,10 +98,14 @@ def test_promote_latest_to_previous_preserves_matching_metadata(tmp_path, monkey
 
     previous_paths = training_job.artifact_paths(previous_dir)
     saved_metadata = json.loads(previous_paths["metadata"].read_text(encoding="utf-8"))
+    saved_evaluation_summary = json.loads(
+        previous_paths["evaluation_summary"].read_text(encoding="utf-8")
+    )
 
     assert previous_paths["model"].read_text(encoding="utf-8") == "model-bytes"
     assert saved_metadata["target"] == "strikeouts"
     assert saved_metadata["training_window"]["train_split_date"] == "2025-08-01"
+    assert saved_evaluation_summary["artifact_type"] == "evaluation_summary"
 
 
 def test_build_training_metadata_includes_richer_evaluation_sections():
@@ -150,6 +167,56 @@ def test_build_training_metadata_includes_richer_evaluation_sections():
     assert metadata["uncertainty_model"]["interval_multiplier"] > 0
     assert metadata["uncertainty_model"]["calibration_rows"] > 0
     assert "documented_interpretation" in metadata["uncertainty_model"]
+
+
+def test_build_evaluation_summary_documents_modes_and_limitations():
+    metadata = {
+        "target": "strikeouts",
+        "training_window": {
+            "raw_statcast_start": "2024-03-28",
+            "raw_statcast_end": "2025-09-30",
+            "train_split_date": "2025-08-01",
+            "train_game_date_range": {"start": "2024-03-28", "end": "2025-07-31"},
+            "test_game_date_range": {"start": "2025-08-01", "end": "2025-09-30"},
+            "train_rows": 250,
+            "test_rows": 40,
+        },
+        "evaluation_metrics": {
+            "regression": {"mae": 0.9},
+            "bucketed_error": {"bucket_by": "predicted_strikeouts", "buckets": [{"rows": 4}]},
+            "uncertainty": {"rows": 40, "empirical_coverage": 0.8},
+            "workflow_backtest": {
+                "available": True,
+                "overall": [{"picks": 12, "decisions": 10, "profit_units": 1.5}],
+                "graded_pick_rows": 12,
+            },
+            "sample_sizes": {"train_rows": 250, "test_rows": 40},
+        },
+        "uncertainty_model": {
+            "documented_interpretation": "held-out interval meaning",
+            "interval_multiplier": 1.2,
+        },
+        "historical_lines_artifact": {
+            "limitations": "selected snapshots only",
+        },
+    }
+
+    summary = training_job.build_evaluation_summary(
+        metadata,
+        workflow_name="mlb_pitcher_strikeouts",
+        artifact_family="default",
+    )
+
+    sections = {section["name"]: section for section in summary["sections"]}
+    assert summary["artifact_type"] == "evaluation_summary"
+    assert sections["holdout_regression"]["mode"] == "fixed_holdout"
+    assert sections["holdout_regression"]["sample_size"]["rows"] == 40
+    assert sections["holdout_regression"]["date_range"]["start"] == "2025-08-01"
+    assert sections["workflow_backtest"]["mode"] == "fixed_holdout_workflow_backtest"
+    assert sections["workflow_backtest"]["sample_size"]["graded_pick_rows"] == 12
+    assert "selected snapshots only" in sections["workflow_backtest"]["limitations"]
+    assert sections["tracked_performance"]["mode"] == "all_time_tracked_performance"
+    assert sections["tracked_performance"]["included_in_reproducible_artifact"] is False
 
 
 def test_build_training_metadata_uses_native_historical_lines_for_real_backtest():

--- a/MLB/tests/jobs/test_build_training_artifacts_pitcher_bb.py
+++ b/MLB/tests/jobs/test_build_training_artifacts_pitcher_bb.py
@@ -33,6 +33,11 @@ def test_save_artifacts_to_dir_writes_pitcher_bb_metadata(tmp_path):
         "training_window": {"train_split_date": "2025-08-01"},
         "evaluation_metrics": {"regression": {"mae": 0.5}},
     }
+    evaluation_summary = {
+        "artifact_type": "evaluation_summary",
+        "artifact_version": 1,
+        "sections": [],
+    }
 
     paths = training_job.save_artifacts_to_dir(
         output_dir=output_dir,
@@ -41,11 +46,15 @@ def test_save_artifacts_to_dir_writes_pitcher_bb_metadata(tmp_path):
         historical_lines_df=historical_lines_df,
         model=FakeModel(),
         metadata=metadata,
+        evaluation_summary=evaluation_summary,
     )
 
     saved_metadata = json.loads(paths["metadata"].read_text(encoding="utf-8"))
+    saved_evaluation_summary = json.loads(paths["evaluation_summary"].read_text(encoding="utf-8"))
     assert paths["metadata"].exists()
+    assert paths["evaluation_summary"].exists()
     assert saved_metadata == metadata
+    assert saved_evaluation_summary == evaluation_summary
 
 
 def test_build_training_metadata_uses_walk_target_and_features():
@@ -92,6 +101,50 @@ def test_build_training_metadata_uses_walk_target_and_features():
     assert metadata["uncertainty_model"]["base_stddev_column"] == "walks_stddev_last10"
     assert metadata["evaluation_metrics"]["bucketed_error"]["bucket_by"] == "predicted_walks"
     assert metadata["evaluation_metrics"]["workflow_backtest"]["available"] is False
+
+
+def test_build_evaluation_summary_marks_backtest_and_tracking_status_for_pitcher_bb():
+    metadata = {
+        "target": "walks",
+        "training_window": {
+            "raw_statcast_start": "2024-03-28",
+            "raw_statcast_end": "2025-09-30",
+            "train_split_date": "2025-08-01",
+            "train_game_date_range": {"start": "2024-03-28", "end": "2025-07-31"},
+            "test_game_date_range": {"start": "2025-08-01", "end": "2025-09-30"},
+            "train_rows": 200,
+            "test_rows": 30,
+        },
+        "evaluation_metrics": {
+            "regression": {"mae": 0.4},
+            "bucketed_error": {"bucket_by": "predicted_walks", "buckets": []},
+            "uncertainty": {"rows": 30, "empirical_coverage": 0.77},
+            "workflow_backtest": {
+                "available": False,
+                "reason": "pitcher_walks_historical_backtest_not_yet_wired",
+                "reproducible_path": None,
+            },
+            "sample_sizes": {"train_rows": 200, "test_rows": 30},
+        },
+        "uncertainty_model": {
+            "documented_interpretation": "held-out interval meaning",
+        },
+        "historical_lines_artifact": {
+            "limitations": "selected snapshots only",
+        },
+    }
+
+    summary = training_job.build_evaluation_summary(
+        metadata,
+        workflow_name="mlb_pitcher_walks",
+        artifact_family="pitcher_bb",
+    )
+
+    sections = {section["name"]: section for section in summary["sections"]}
+    assert sections["holdout_regression"]["mode"] == "fixed_holdout"
+    assert sections["workflow_backtest"]["available"] is False
+    assert "pitcher_walks_historical_backtest_not_yet_wired" in sections["workflow_backtest"]["limitations"]
+    assert sections["tracked_performance"]["included_in_reproducible_artifact"] is False
 
 
 def test_train_pitcher_bb_model_filters_to_starter_like_appearances(monkeypatch):

--- a/README.md
+++ b/README.md
@@ -82,8 +82,11 @@ proGramble/
    - `pitcher_games.csv`
    - `model_df.csv`
    - `metadata.json`
+   - `evaluation_summary.json`
 
 Artifacts are written to `MLB/data/artifacts/_staging/`, validated, then promoted into `latest/`. If a previous `latest/` artifact set exists, it is copied into `previous/` first.
+
+`evaluation_summary.json` is the stable review artifact for model quality. It consolidates fixed-holdout regression metrics, fixed-holdout workflow backtest results, sample sizes, date ranges, and explicit limitations, while also documenting which evaluation modes are intentionally excluded from the reproducible build.
 
 ### 2. Daily card workflow
 


### PR DESCRIPTION
The new summary explicitly labels each section by evaluation mode: fixed holdout regression, fixed holdout uncertainty, fixed holdout bucketed error, fixed holdout workflow backtest, and tracked performance as intentionally excluded from the reproducible build. That gives us one durable artifact with metrics, sample sizes, date ranges, and limitations, while keeping daily operational tracking separate. I also updated the repo docs in README.md (line 85) and added contract tests for both workflows in test_build_training_artifacts.py (line 172) and test_build_training_artifacts_pitcher_bb.py (line 106).

Verification: pytest tests/jobs/test_build_training_artifacts.py tests/jobs/test_build_training_artifacts_pitcher_bb.py passed with 12 passed.

One deliberate product choice: I did not fold all-time tracked betting performance into the reproducible artifact, because that would re-couple model evaluation to operational history files. Instead, the summary now documents that exclusion explicitly, which keeps the artifact stable and credible for model-to-model comparison.