### PR TITLE
updated the live-odds path so it now tells us what actually failed in…

### DIFF
--- a/MLB/src/jobs/run_daily_card.py
+++ b/MLB/src/jobs/run_daily_card.py
@@ -1000,6 +1000,47 @@ def workflow_is_ready(workflow: ModelingWorkflowSpec) -> bool:
     return True
 
 
+def _build_no_edges_message(
+    *,
+    workflow: ModelingWorkflowSpec,
+    diagnostics: dict[str, object] | None,
+) -> str:
+    diagnostics = diagnostics or {}
+    normalized_odds_rows = int(diagnostics.get("normalized_odds_rows", 0) or 0)
+    raw_event_count = int(diagnostics.get("raw_event_count", 0) or 0)
+    joined_rows = int(diagnostics.get("joined_rows", 0) or 0)
+    fetch_scope = str(diagnostics.get("fetch_scope", "") or "")
+    initial_fetch = diagnostics.get("initial_fetch")
+    initial_odds_rows = 0
+    if isinstance(initial_fetch, dict):
+        initial_odds_rows = int(initial_fetch.get("normalized_odds_rows", 0) or 0)
+
+    if normalized_odds_rows == 0 and initial_odds_rows == 0:
+        if fetch_scope == "all_region_books":
+            return (
+                "No live odds rows were returned for today's "
+                f"{workflow.prop_type} market from either the configured bookmakers or the broader "
+                "US bookmaker feed, so no edges or picks were generated."
+            )
+        return (
+            "No live odds rows were returned for today's "
+            f"{workflow.prop_type} market from the configured bookmakers, so no edges or picks "
+            "were generated."
+        )
+
+    if joined_rows == 0:
+        return (
+            "Live odds were available for today's "
+            f"{workflow.prop_type} market ({normalized_odds_rows} normalized rows across "
+            f"{raw_event_count} event(s)), but none matched today's projections, so no edges or "
+            "picks were generated."
+        )
+
+    return (
+        f"No edges or picks were generated for today's {workflow.prop_type} run."
+    )
+
+
 def resolve_daily_card_workflows(
     workflows: list[ModelingWorkflowSpec] | None = None,
 ) -> list[ModelingWorkflowSpec]:
@@ -1067,7 +1108,7 @@ def run_workflow_daily_card(
     run_message: str | None = None
 
     try:
-        joined_df, _ = run_edge_pipeline(
+        joined_df, _, edge_diagnostics = run_edge_pipeline(
             today_preds,
             selected_market,
             participant_key=workflow.participant_key,
@@ -1081,9 +1122,9 @@ def run_workflow_daily_card(
         joined_df = _tag_workflow_frame(joined_df, workflow)
         if joined_df.empty:
             run_status = "degraded"
-            run_message = (
-                "Live odds were fetched but no matching odds rows were available for today's "
-                f"{workflow.prop_type} projections, so no edges or picks were generated."
+            run_message = _build_no_edges_message(
+                workflow=workflow,
+                diagnostics=edge_diagnostics,
             )
             print(f"WARNING: {run_message}")
             joined_df = _tag_workflow_frame(empty_joined_odds_df(), workflow)

--- a/MLB/src/odds/odds_api.py
+++ b/MLB/src/odds/odds_api.py
@@ -20,7 +20,7 @@ def summarize_event_bookmaker_coverage(
     *,
     requested_bookmakers: list[str] | None = None,
 ) -> dict[str, object]:
-    requested = requested_bookmakers or BOOKMAKERS
+    requested = requested_bookmakers or []
     upstream_bookmaker_keys = sorted(
         {
             bookmaker.get("key", "")
@@ -68,10 +68,11 @@ def fetch_mlb_events(
         "apiKey": ODDS_API_KEY,
         "regions": "us",
         "markets": market,
-        "bookmakers": ",".join(bookmakers),
         "oddsFormat": odds_format,
         "dateFormat": date_format,
     }
+    if bookmakers:
+        params["bookmakers"] = ",".join(bookmakers)
 
     response = requests.get(url, params=params, timeout=30)
     response.raise_for_status()
@@ -100,10 +101,11 @@ def fetch_event_player_props(
         "apiKey": ODDS_API_KEY,
         "regions": "us",
         "markets": market,
-        "bookmakers": ",".join(bookmakers),
         "oddsFormat": odds_format,
         "dateFormat": date_format,
     }
+    if bookmakers:
+        params["bookmakers"] = ",".join(bookmakers)
 
     response = requests.get(url, params=params, timeout=30)
     response.raise_for_status()
@@ -114,12 +116,14 @@ def fetch_all_player_props(
     market: str,
     sport: str = ODDS_SPORT,
     bookmakers: list[str] | None = None,
+    *,
+    use_configured_bookmakers: bool = True,
 ) -> list[dict]:
     """
     Fetch player prop odds for all today's MLB events for the given market.
     Returns a list of event-level prop payloads.
     """
-    if bookmakers is None:
+    if bookmakers is None and use_configured_bookmakers:
         bookmakers = BOOKMAKERS
 
     events = fetch_mlb_events(sport=sport, bookmakers=bookmakers)

--- a/MLB/src/odds/run_edges.py
+++ b/MLB/src/odds/run_edges.py
@@ -8,6 +8,25 @@ from .normalize import odds_json_to_dataframe
 from .compare import join_projections_to_odds, best_over_edges
 
 
+def _build_edge_pipeline_diagnostics(
+    *,
+    fetch_scope: str,
+    raw_events: list[dict],
+    odds_df: pd.DataFrame,
+    joined_df: pd.DataFrame,
+    best_edges_df: pd.DataFrame,
+    bookmaker_filter_applied: bool,
+) -> dict[str, object]:
+    return {
+        "fetch_scope": fetch_scope,
+        "bookmaker_filter_applied": bookmaker_filter_applied,
+        "raw_event_count": int(len(raw_events)),
+        "normalized_odds_rows": int(len(odds_df)),
+        "joined_rows": int(len(joined_df)),
+        "best_edge_rows": int(len(best_edges_df)),
+    }
+
+
 def run_edge_pipeline(
     projections: pd.DataFrame,
     market: str,
@@ -17,12 +36,40 @@ def run_edge_pipeline(
     projection_join_key: str = PARTICIPANT_JOIN_KEY_COLUMN,
     odds_join_key: str = PARTICIPANT_JOIN_KEY_COLUMN,
     sport: str = "MLB",
-) -> tuple[pd.DataFrame, pd.DataFrame]:
+) -> tuple[pd.DataFrame, pd.DataFrame, dict[str, object]]:
+    fetch_scope = "configured_books"
+    bookmaker_filter_applied = True
     raw_events = fetch_all_player_props(market=market)
     odds_df = odds_json_to_dataframe(raw_events)
 
     if odds_df.empty:
-        return pd.DataFrame(), pd.DataFrame()
+        retry_events = fetch_all_player_props(
+            market=market,
+            use_configured_bookmakers=False,
+        )
+        retry_odds_df = odds_json_to_dataframe(retry_events)
+        if retry_odds_df.empty:
+            diagnostics = _build_edge_pipeline_diagnostics(
+                fetch_scope="all_region_books",
+                raw_events=retry_events,
+                odds_df=retry_odds_df,
+                joined_df=pd.DataFrame(),
+                best_edges_df=pd.DataFrame(),
+                bookmaker_filter_applied=False,
+            )
+            diagnostics["initial_fetch"] = _build_edge_pipeline_diagnostics(
+                fetch_scope="configured_books",
+                raw_events=raw_events,
+                odds_df=odds_df,
+                joined_df=pd.DataFrame(),
+                best_edges_df=pd.DataFrame(),
+                bookmaker_filter_applied=True,
+            )
+            return pd.DataFrame(), pd.DataFrame(), diagnostics
+        raw_events = retry_events
+        odds_df = retry_odds_df
+        fetch_scope = "all_region_books"
+        bookmaker_filter_applied = False
 
     joined = join_projections_to_odds(
         projections,
@@ -36,8 +83,24 @@ def run_edge_pipeline(
     )
 
     if joined.empty:
-        return joined, pd.DataFrame()
+        diagnostics = _build_edge_pipeline_diagnostics(
+            fetch_scope=fetch_scope,
+            raw_events=raw_events,
+            odds_df=odds_df,
+            joined_df=joined,
+            best_edges_df=pd.DataFrame(),
+            bookmaker_filter_applied=bookmaker_filter_applied,
+        )
+        return joined, pd.DataFrame(), diagnostics
 
     group_key = PARTICIPANT_JOIN_KEY_COLUMN if PARTICIPANT_JOIN_KEY_COLUMN in joined.columns else f"{participant_key}_proj"
     best_edges = best_over_edges(joined, group_key=group_key)
-    return joined, best_edges
+    diagnostics = _build_edge_pipeline_diagnostics(
+        fetch_scope=fetch_scope,
+        raw_events=raw_events,
+        odds_df=odds_df,
+        joined_df=joined,
+        best_edges_df=best_edges,
+        bookmaker_filter_applied=bookmaker_filter_applied,
+    )
+    return joined, best_edges, diagnostics

--- a/MLB/tests/jobs/test_run_daily_card.py
+++ b/MLB/tests/jobs/test_run_daily_card.py
@@ -112,7 +112,7 @@ def test_run_daily_card_writes_outputs_with_mocked_dependencies(monkeypatch, tmp
 
     def fake_run_edge_pipeline(preds, market, **kwargs):
         assert market == PITCHER_K_PROP_MARKET
-        return joined_df, joined_df
+        return joined_df, joined_df, {"raw_event_count": 1, "normalized_odds_rows": 1, "joined_rows": 1}
 
     monkeypatch.setattr(daily_card, "run_edge_pipeline", fake_run_edge_pipeline)
     monkeypatch.setattr(
@@ -317,7 +317,7 @@ def test_run_daily_card_allows_explicit_market_and_workflow_behavior(monkeypatch
     def fake_run_edge_pipeline(preds, market, **kwargs):
         calls["market"] = market
         calls["join_kwargs"] = kwargs
-        return joined_df, joined_df
+        return joined_df, joined_df, {"raw_event_count": 1, "normalized_odds_rows": 1, "joined_rows": 1}
 
     def fake_build_picks(joined):
         calls["build_picks_joined"] = joined.copy()
@@ -583,7 +583,7 @@ def test_run_daily_card_uses_workflow_spec_for_market_policy_and_limits(monkeypa
     def fake_run_edge_pipeline(preds, market, **kwargs):
         calls["market"] = market
         calls["join_kwargs"] = kwargs
-        return joined_df, joined_df
+        return joined_df, joined_df, {"raw_event_count": 1, "normalized_odds_rows": 1, "joined_rows": 1}
 
     def fake_build_daily_picks(df, policy, prediction_column="predicted_value"):
         calls["build_policy"] = policy
@@ -715,7 +715,7 @@ def test_run_daily_card_default_workflow_joins_live_odds_on_normalized_name(monk
     def fake_run_edge_pipeline(preds, market, **kwargs):
         calls["joined_preds"] = preds.copy()
         calls["join_kwargs"] = kwargs
-        return joined_df, joined_df
+        return joined_df, joined_df, {"raw_event_count": 1, "normalized_odds_rows": 1, "joined_rows": 1}
 
     monkeypatch.setattr(daily_card, "run_edge_pipeline", fake_run_edge_pipeline)
     monkeypatch.setattr(
@@ -850,6 +850,31 @@ def test_resolve_daily_card_workflows_includes_pitcher_walks_only_when_ready(mon
         daily_card.MLB_PITCHER_STRIKEOUT_WORKFLOW,
         daily_card.MLB_PITCHER_WALK_WORKFLOW,
     ]
+
+
+def test_build_no_edges_message_distinguishes_empty_odds_from_join_miss():
+    no_odds_message = daily_card._build_no_edges_message(
+        workflow=MLB_PITCHER_WALK_WORKFLOW,
+        diagnostics={
+            "fetch_scope": "all_region_books",
+            "raw_event_count": 0,
+            "normalized_odds_rows": 0,
+            "joined_rows": 0,
+            "initial_fetch": {"normalized_odds_rows": 0},
+        },
+    )
+    no_join_message = daily_card._build_no_edges_message(
+        workflow=MLB_PITCHER_WALK_WORKFLOW,
+        diagnostics={
+            "fetch_scope": "configured_books",
+            "raw_event_count": 7,
+            "normalized_odds_rows": 24,
+            "joined_rows": 0,
+        },
+    )
+
+    assert "No live odds rows were returned" in no_odds_message
+    assert "none matched today's projections" in no_join_message
 
 
 def test_run_daily_card_combines_ready_workflow_outputs(monkeypatch, tmp_path):
@@ -1072,7 +1097,7 @@ def test_run_workflow_daily_card_uses_pitcher_walk_market_and_validates_joined_o
         calls["market"] = market
         calls["join_kwargs"] = kwargs
         calls["preds"] = preds.copy()
-        return joined_df, joined_df
+        return joined_df, joined_df, {"raw_event_count": 1, "normalized_odds_rows": 1, "joined_rows": 1}
 
     def fake_build_daily_picks(df, policy, prediction_column="predicted_value"):
         calls["prediction_column"] = prediction_column
@@ -1502,7 +1527,15 @@ def test_run_daily_card_handles_empty_joined_odds_gracefully(monkeypatch, tmp_pa
         "build_today_predictions_for_workflow",
         lambda *, starters_df, pitcher_games, model, workflow: today_preds,
     )
-    monkeypatch.setattr(daily_card, "run_edge_pipeline", lambda *args, **kwargs: (pd.DataFrame(), pd.DataFrame()))
+    monkeypatch.setattr(
+        daily_card,
+        "run_edge_pipeline",
+        lambda *args, **kwargs: (
+            pd.DataFrame(),
+            pd.DataFrame(),
+            {"raw_event_count": 0, "normalized_odds_rows": 0, "joined_rows": 0},
+        ),
+    )
 
     monkeypatch.setattr(daily_card, "DATA_DIR", tmp_path / "data")
     monkeypatch.setattr(daily_card, "OUTPUT_DIR", tmp_path / "data" / "outputs")
@@ -1557,7 +1590,7 @@ def test_run_daily_card_handles_empty_joined_odds_gracefully(monkeypatch, tmp_pa
     assert loaded_picks.empty
     assert loaded_post.empty
     assert status_payload["status"] == "degraded"
-    assert "no matching odds rows were available" in status_payload["message"]
+    assert "No live odds rows were returned" in status_payload["message"]
 
 
 def test_run_daily_card_degraded_run_does_not_overwrite_existing_tracking_summaries(
@@ -1631,7 +1664,15 @@ def test_run_daily_card_degraded_run_does_not_overwrite_existing_tracking_summar
         "build_today_predictions_for_workflow",
         lambda *, starters_df, pitcher_games, model, workflow: today_preds,
     )
-    monkeypatch.setattr(daily_card, "run_edge_pipeline", lambda *args, **kwargs: (pd.DataFrame(), pd.DataFrame()))
+    monkeypatch.setattr(
+        daily_card,
+        "run_edge_pipeline",
+        lambda *args, **kwargs: (
+            pd.DataFrame(),
+            pd.DataFrame(),
+            {"raw_event_count": 0, "normalized_odds_rows": 0, "joined_rows": 0},
+        ),
+    )
 
     monkeypatch.setattr(daily_card, "DATA_DIR", tmp_path / "data")
     monkeypatch.setattr(daily_card, "OUTPUT_DIR", outputs_dir)

--- a/MLB/tests/odds/test_run_edges.py
+++ b/MLB/tests/odds/test_run_edges.py
@@ -64,13 +64,16 @@ def test_run_edge_pipeline_returns_joined_and_best_edges(monkeypatch):
         fake_fetch_all_player_props,
     )
 
-    joined, best = run_edges.run_edge_pipeline(
+    joined, best, diagnostics = run_edges.run_edge_pipeline(
         projections,
         market=PITCHER_K_PROP_MARKET,
     )
 
     assert len(joined) == 2
     assert len(best) == 1
+    assert diagnostics["raw_event_count"] == 1
+    assert diagnostics["normalized_odds_rows"] == 2
+    assert diagnostics["joined_rows"] == 2
     assert best.iloc[0]["player_name_proj"] == "Jacob deGrom"
     assert best.iloc[0]["bookmaker"] == "DraftKings"
 
@@ -87,7 +90,7 @@ def test_run_edge_pipeline_returns_empty_when_no_odds(monkeypatch):
         ]
     )
 
-    def fake_fetch_all_player_props(market):
+    def fake_fetch_all_player_props(market, **kwargs):
         assert market == PITCHER_K_PROP_MARKET
         return []
 
@@ -97,7 +100,7 @@ def test_run_edge_pipeline_returns_empty_when_no_odds(monkeypatch):
         fake_fetch_all_player_props,
     )
 
-    joined, best = run_edges.run_edge_pipeline(
+    joined, best, diagnostics = run_edges.run_edge_pipeline(
         projections,
         market=PITCHER_K_PROP_MARKET,
     )
@@ -106,6 +109,7 @@ def test_run_edge_pipeline_returns_empty_when_no_odds(monkeypatch):
     assert isinstance(best, pd.DataFrame)
     assert joined.empty
     assert best.empty
+    assert diagnostics["normalized_odds_rows"] == 0
 
 
 def test_run_edge_pipeline_returns_empty_when_odds_do_not_match_projection_names(monkeypatch):
@@ -164,13 +168,15 @@ def test_run_edge_pipeline_returns_empty_when_odds_do_not_match_projection_names
         fake_fetch_all_player_props,
     )
 
-    joined, best = run_edges.run_edge_pipeline(
+    joined, best, diagnostics = run_edges.run_edge_pipeline(
         projections,
         market=PITCHER_K_PROP_MARKET,
     )
 
     assert joined.empty
     assert best.empty
+    assert diagnostics["normalized_odds_rows"] == 2
+    assert diagnostics["joined_rows"] == 0
 
 
 def test_run_edge_pipeline_handles_pitcher_walks_market_with_shared_odds_shape(monkeypatch):
@@ -227,7 +233,7 @@ def test_run_edge_pipeline_handles_pitcher_walks_market_with_shared_odds_shape(m
 
     monkeypatch.setattr(run_edges, "fetch_all_player_props", fake_fetch_all_player_props)
 
-    joined, best = run_edges.run_edge_pipeline(
+    joined, best, diagnostics = run_edges.run_edge_pipeline(
         projections,
         market=PITCHER_BB_PROP_MARKET,
         prediction_column="predicted_value",
@@ -240,4 +246,70 @@ def test_run_edge_pipeline_handles_pitcher_walks_market_with_shared_odds_shape(m
     assert set(joined["market_key"]) == {PITCHER_BB_PROP_MARKET}
     assert set(joined["player_name_norm"]) == {"tarik skubal"}
     assert joined["predicted_value"].iloc[0] == 2.2
+    assert diagnostics["joined_rows"] == 2
     assert best.iloc[0]["player_name_proj"] == "Tarik Skubal"
+
+
+def test_run_edge_pipeline_retries_without_bookmaker_filter_when_filtered_fetch_has_no_rows(monkeypatch):
+    projections = pd.DataFrame(
+        [
+            {
+                "player_name": "Tarik Skubal",
+                "predicted_walks": 2.2,
+                "predicted_value": 2.2,
+                "player_name_norm": "tarik skubal",
+            }
+        ]
+    )
+
+    calls: list[bool] = []
+
+    def fake_fetch_all_player_props(market, **kwargs):
+        assert market == PITCHER_BB_PROP_MARKET
+        use_configured = kwargs.get("use_configured_bookmakers", True)
+        calls.append(use_configured)
+        if use_configured:
+            return []
+        return [
+            {
+                "id": "game_2",
+                "commence_time": "2026-04-18T19:10:00Z",
+                "home_team": "Detroit Tigers",
+                "away_team": "Cleveland Guardians",
+                "bookmakers": [
+                    {
+                        "key": "fanduel",
+                        "last_update": "2026-04-18T14:00:00Z",
+                        "markets": [
+                            {
+                                "key": PITCHER_BB_PROP_MARKET,
+                                "outcomes": [
+                                    {
+                                        "name": "Over",
+                                        "description": "Tarik Skubal",
+                                        "point": 1.5,
+                                        "price": -102,
+                                    }
+                                ],
+                            }
+                        ],
+                    }
+                ],
+            }
+        ]
+
+    monkeypatch.setattr(run_edges, "fetch_all_player_props", fake_fetch_all_player_props)
+
+    joined, best, diagnostics = run_edges.run_edge_pipeline(
+        projections,
+        market=PITCHER_BB_PROP_MARKET,
+        prediction_column="predicted_value",
+        projection_join_key="player_name_norm",
+        odds_join_key="player_name_norm",
+    )
+
+    assert calls == [True, False]
+    assert len(joined) == 1
+    assert len(best) == 1
+    assert diagnostics["fetch_scope"] == "all_region_books"
+    assert diagnostics["bookmaker_filter_applied"] is False


### PR DESCRIPTION
run_edge_pipeline now returns diagnostics with raw_event_count, normalized_odds_rows, joined_rows, and best_edge_rows in run_edges.py (line 30). I also added a fallback fetch: if the configured bookmaker set yields zero normalized odds rows, we retry once without the bookmaker filter via odds_api.py (line 120). That’s the concrete change most likely to make pitcher_bb picks appear tomorrow if pitcher_walks exists somewhere in the broader US feed but not in the current preferred book set.

In run_daily_card.py (line 1003), the degraded message is now diagnostic:


if no live odds rows exist, it says that explicitly

if live odds exist but zero rows join to projections, it says the odds were available but none matched