### PR TITLE
 fixed this at the test harness level so tracking isolation is now th…

### DIFF
--- a/MLB/tests/conftest.py
+++ b/MLB/tests/conftest.py
@@ -1,13 +1,16 @@
 from __future__ import annotations
 
+import hashlib
 import shutil
 from pathlib import Path
 
 import pytest
 
 
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
 FIXTURES_DIR = Path(__file__).resolve().parent / "fixtures"
 HISTORICAL_LINES_FIXTURES_DIR = FIXTURES_DIR / "historical_lines"
+TRACKING_DIR = PROJECT_ROOT / "data" / "tracking"
 
 
 def copy_historical_lines_fixtures(destination: Path) -> list[Path]:
@@ -25,3 +28,56 @@ def historical_lines_fixture_dir(tmp_path: Path) -> Path:
     raw_dir = tmp_path / "raw" / "historical_lines"
     copy_historical_lines_fixtures(raw_dir)
     return raw_dir
+
+
+def _tracking_file_digests() -> dict[Path, str]:
+    digests: dict[Path, str] = {}
+    if not TRACKING_DIR.exists():
+        return digests
+
+    for path in sorted(TRACKING_DIR.iterdir()):
+        if path.is_file():
+            digests[path] = hashlib.sha256(path.read_bytes()).hexdigest()
+    return digests
+
+
+@pytest.fixture(scope="session", autouse=True)
+def guard_committed_tracking_artifacts_unchanged():
+    before = _tracking_file_digests()
+    yield
+    after = _tracking_file_digests()
+    assert after == before, "Pytest modified committed files under MLB/data/tracking/."
+
+
+@pytest.fixture(autouse=True)
+def isolate_tracking_artifacts(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    from jobs import run_daily_card as daily_card
+
+    tracking_dir = tmp_path / "data" / "tracking"
+    monkeypatch.setattr(daily_card, "TRACKING_DIR", tracking_dir)
+    monkeypatch.setattr(
+        daily_card,
+        "OFFICIAL_PICKS_HISTORY_PATH",
+        tracking_dir / "official_picks_history.csv",
+    )
+    monkeypatch.setattr(
+        daily_card,
+        "OFFICIAL_PICKS_GRADES_PATH",
+        tracking_dir / "official_picks_profit_report.csv",
+    )
+    monkeypatch.setattr(
+        daily_card,
+        "OFFICIAL_PICKS_BOOK_SUMMARY_PATH",
+        tracking_dir / "official_picks_profit_by_book.csv",
+    )
+    monkeypatch.setattr(
+        daily_card,
+        "OFFICIAL_PICKS_OVERALL_SUMMARY_PATH",
+        tracking_dir / "official_picks_profit_summary.json",
+    )
+    monkeypatch.setattr(
+        daily_card,
+        "OFFICIAL_PICKS_SKIPPED_PATH",
+        tracking_dir / "official_picks_profit_skipped.csv",
+    )
+    return tracking_dir

--- a/MLB/tests/jobs/test_run_daily_card.py
+++ b/MLB/tests/jobs/test_run_daily_card.py
@@ -15,6 +15,18 @@ from pitcher_bb.workflow import MLB_PITCHER_WALK_WORKFLOW
 from pitcher_k.config import PITCHER_K_PROP_MARKET
 
 
+def test_tracking_artifact_paths_are_isolated_from_committed_repo_files(tmp_path):
+    committed_tracking_dir = daily_card.PROJECT_ROOT / "data" / "tracking"
+
+    assert daily_card.TRACKING_DIR != committed_tracking_dir
+    assert daily_card.OFFICIAL_PICKS_HISTORY_PATH.parent == daily_card.TRACKING_DIR
+    assert committed_tracking_dir not in daily_card.OFFICIAL_PICKS_HISTORY_PATH.parents
+    assert committed_tracking_dir not in daily_card.OFFICIAL_PICKS_GRADES_PATH.parents
+    assert committed_tracking_dir not in daily_card.OFFICIAL_PICKS_BOOK_SUMMARY_PATH.parents
+    assert committed_tracking_dir not in daily_card.OFFICIAL_PICKS_OVERALL_SUMMARY_PATH.parents
+    assert committed_tracking_dir not in daily_card.OFFICIAL_PICKS_SKIPPED_PATH.parents
+
+
 def test_run_daily_card_writes_outputs_with_mocked_dependencies(monkeypatch, tmp_path):
     starters_df = pd.DataFrame(
         [


### PR DESCRIPTION
In conftest.py (line 53), I added an autouse fixture that redirects all run_daily_card tracking/report paths into a per-test temp directory. That means any test calling daily-card persistence now writes only under tmp_path, even if it forgets to monkeypatch the tracking constants itself. I also added a session-level guard in conftest.py (line 45) that snapshots committed files under MLB/data/tracking/ before pytest and fails the run if any of them change.

For regression coverage, I added test_tracking_artifact_paths_are_isolated_from_committed_repo_files (line 18), which asserts the active tracking paths used by tests are not inside the committed repo tracking directory.

Verification:


pytest tests/jobs/test_run_daily_card.py passed: 29 passed

pytest ran through the suite without mutating MLB/data/tracking/, but it still has one unrelated pre-existing failure in tests/starters/test_today_starters_integration_unit.py about lowercased starter names