### PR TITLE
Implemented the full pitcher_k shadow grading and comparison workflow…

### DIFF
--- a/MLB/src/jobs/run_daily_card.py
+++ b/MLB/src/jobs/run_daily_card.py
@@ -35,6 +35,7 @@ from common.identity import (
 )
 from common.workflows import ModelingWorkflowSpec
 from pitcher_k.workflow import MLB_PITCHER_STRIKEOUT_WORKFLOW
+from pitcher_k import shadow as pitcher_k_shadow
 from pitcher_bb.workflow import MLB_PITCHER_WALK_WORKFLOW
 from pitcher_k.data_loader import load_statcast_data
 from pitcher_k.feature_engineering import build_pitcher_game_table
@@ -61,6 +62,11 @@ OFFICIAL_PICKS_ALL_TIME_SUMMARY_PATH = TRACKING_DIR / "official_picks_profit_sum
 OFFICIAL_PICKS_CURRENT_REGIME_SUMMARY_PATH = TRACKING_DIR / "official_picks_profit_summary_current_regime.json"
 OFFICIAL_PICKS_SKIPPED_PATH = TRACKING_DIR / "official_picks_profit_skipped.csv"
 OFFICIAL_PICKS_CONCENTRATION_AUDIT_PATH = TRACKING_DIR / "official_picks_concentration_audit.json"
+PITCHER_K_SHADOW_TRACKING_PATH = TRACKING_DIR / "pitcher_k_shadow_predictions.csv"
+PITCHER_K_SHADOW_OVERLAP_PATH = TRACKING_DIR / "pitcher_k_shadow_overlap.csv"
+PITCHER_K_SHADOW_SUMMARY_PATH = TRACKING_DIR / "pitcher_k_shadow_summary.json"
+PITCHER_K_SHADOW_REGRESSION_PLOT_PATH = TRACKING_DIR / "pitcher_k_shadow_regression.png"
+PITCHER_K_SHADOW_WORKFLOW_PLOT_PATH = TRACKING_DIR / "pitcher_k_shadow_workflow.png"
 CURRENT_REGIME_START_DATE = "2026-05-07"
 LEGACY_WORKFLOW_MODEL_VERSION = "workflow_unversioned"
 LEGACY_MANUAL_MODEL_VERSION = "manual_unversioned"
@@ -175,6 +181,18 @@ def ensure_output_dirs() -> None:
 
 def empty_official_picks_history_df() -> pd.DataFrame:
     return pd.DataFrame(columns=OFFICIAL_PICKS_HISTORY_COLUMNS)
+
+
+def empty_pitcher_k_shadow_tracking_df() -> pd.DataFrame:
+    return pitcher_k_shadow.empty_shadow_tracking_df()
+
+
+def load_pitcher_k_shadow_tracking() -> pd.DataFrame:
+    if not PITCHER_K_SHADOW_TRACKING_PATH.exists():
+        return empty_pitcher_k_shadow_tracking_df()
+
+    shadow_df = pd.read_csv(PITCHER_K_SHADOW_TRACKING_PATH, keep_default_na=False)
+    return pitcher_k_shadow.coerce_shadow_tracking_df(shadow_df)
 
 
 def empty_joined_odds_df() -> pd.DataFrame:
@@ -363,6 +381,116 @@ def _annotate_workflow_provenance(
     annotated["policy_version"] = workflow.pick_ranking_policy.version
     annotated["tracking_regime"] = _infer_tracking_regime("run_daily_card", game_date)
     return annotated
+
+
+def _upsert_pitcher_k_shadow_rows(
+    existing_df: pd.DataFrame,
+    new_rows: pd.DataFrame,
+) -> pd.DataFrame:
+    existing = pitcher_k_shadow.coerce_shadow_tracking_df(existing_df)
+    incoming = pitcher_k_shadow.coerce_shadow_tracking_df(new_rows)
+    if incoming.empty:
+        return existing
+    if existing.empty:
+        return incoming
+
+    existing_by_key = existing.set_index("shadow_row_key", drop=False)
+    merged_rows: list[dict[str, object]] = []
+    for _, incoming_row in incoming.iterrows():
+        new_record = incoming_row.to_dict()
+        row_key = str(new_record["shadow_row_key"])
+        if row_key in existing_by_key.index:
+            existing_record = existing_by_key.loc[row_key].to_dict()
+            for field in ["actual_value", "result", "profit_units", "graded_at"]:
+                new_value = new_record.get(field)
+                existing_value = existing_record.get(field)
+                if (
+                    (pd.isna(new_value) or str(new_value).strip() == "")
+                    and not pd.isna(existing_value)
+                    and str(existing_value).strip() != ""
+                ):
+                    new_record[field] = existing_value
+        merged_rows.append(new_record)
+
+    merged_df = pd.DataFrame(merged_rows, columns=pitcher_k_shadow.SHADOW_TRACKING_COLUMNS)
+    untouched_existing = existing[~existing["shadow_row_key"].isin(merged_df["shadow_row_key"])]
+    combined = pd.concat([untouched_existing, merged_df], ignore_index=True)
+    return pitcher_k_shadow.coerce_shadow_tracking_df(combined)
+
+
+def persist_pitcher_k_shadow_predictions(
+    *,
+    starters_df: pd.DataFrame,
+    pitcher_games: pd.DataFrame,
+    joined_df: pd.DataFrame,
+    picks_df: pd.DataFrame,
+    workflow: ModelingWorkflowSpec,
+    metadata: dict | None,
+    build_picks_fn: BuildPicksFn,
+) -> Path:
+    ensure_output_dirs()
+    existing_df = load_pitcher_k_shadow_tracking()
+    if workflow.prop_type != "pitcher_k" or joined_df.empty:
+        if not PITCHER_K_SHADOW_TRACKING_PATH.exists():
+            existing_df.to_csv(PITCHER_K_SHADOW_TRACKING_PATH, index=False)
+        return PITCHER_K_SHADOW_TRACKING_PATH
+
+    workflow_game_date = pd.to_datetime(starters_df["game_date"], errors="coerce").min()
+    tracking_regime = _infer_tracking_regime("run_daily_card", workflow_game_date)
+    champion_rows = pitcher_k_shadow.build_shadow_candidate_rows(
+        joined_df,
+        picks_df,
+        model_name=pitcher_k_shadow.CHAMPION_MODEL_NAME,
+        model_role=pitcher_k_shadow.CHAMPION_MODEL_ROLE,
+        model_version=_resolve_model_version(workflow, metadata),
+        policy_version=workflow.pick_ranking_policy.version,
+        tracking_regime=tracking_regime,
+        game_date=workflow_game_date,
+    )
+
+    today_features = workflow.feature_builder(starters_df, pitcher_games)
+    challenger_preds, challenger_meta = pitcher_k_shadow.build_ridge_shadow_predictions(
+        today_features,
+        pitcher_games,
+    )
+    challenger_joined_df = pitcher_k_shadow.apply_prediction_frame_to_joined_rows(
+        joined_df,
+        challenger_preds,
+        prediction_column=workflow.prop_fields.shared_prediction,
+        prop_prediction_column=workflow.prop_fields.prediction,
+    )
+    challenger_joined_df = _tag_workflow_frame(challenger_joined_df, workflow)
+    challenger_joined_df = _annotate_workflow_provenance(
+        challenger_joined_df,
+        workflow=workflow,
+        metadata=metadata,
+        game_date=workflow_game_date,
+    )
+    challenger_picks_df = build_picks_fn(challenger_joined_df)
+    challenger_picks_df = _tag_workflow_frame(challenger_picks_df, workflow)
+    challenger_picks_df = _annotate_workflow_provenance(
+        challenger_picks_df,
+        workflow=workflow,
+        metadata=metadata,
+        game_date=workflow_game_date,
+    )
+    challenger_rows = pitcher_k_shadow.build_shadow_candidate_rows(
+        challenger_joined_df,
+        challenger_picks_df,
+        model_name=str(challenger_meta["model_name"]),
+        model_role=str(challenger_meta["model_role"]),
+        model_version=str(challenger_meta["model_version"]),
+        policy_version=workflow.pick_ranking_policy.version,
+        tracking_regime=tracking_regime,
+        game_date=workflow_game_date,
+    )
+
+    merged_df = _upsert_pitcher_k_shadow_rows(
+        existing_df,
+        pd.concat([champion_rows, challenger_rows], ignore_index=True),
+    )
+    merged_df.to_csv(PITCHER_K_SHADOW_TRACKING_PATH, index=False)
+    return PITCHER_K_SHADOW_TRACKING_PATH
 
 
 def _parse_american_odds(odds: float | int | str | None) -> float | None:
@@ -596,6 +724,178 @@ def grade_official_picks_from_statcast(
         "game_date": target_date,
         "updated_rows": updated_rows,
         "history_df": updated_history_df,
+    }
+
+
+def apply_statcast_results_to_pitcher_k_shadow_tracking(
+    shadow_df: pd.DataFrame,
+    pitcher_results_df: pd.DataFrame,
+    *,
+    game_date: str,
+) -> pd.DataFrame:
+    working = pitcher_k_shadow.coerce_shadow_tracking_df(shadow_df)
+    if working.empty:
+        return working
+
+    working = ensure_participant_identity(
+        working,
+        display_name_col="player_name",
+        normalized_name_col=PARTICIPANT_NAME_NORM_COLUMN,
+        source_id_col=PARTICIPANT_SOURCE_ID_COLUMN,
+        source_id_type="mlbam_player",
+    )
+
+    if pitcher_results_df.empty:
+        return working
+
+    pitcher_results = pitcher_results_df.copy()
+    pitcher_results = ensure_participant_identity(
+        pitcher_results,
+        display_name_col="player_name",
+        source_id_col="pitcher" if "pitcher" in pitcher_results.columns else PARTICIPANT_SOURCE_ID_COLUMN,
+        source_id_type="mlbam_player",
+    )
+    for stat_column in ["strikeouts", "walks"]:
+        if stat_column not in pitcher_results.columns:
+            pitcher_results[stat_column] = pd.NA
+
+    result_lookup = pitcher_results.drop_duplicates(
+        subset=["game_date", PARTICIPANT_JOIN_KEY_COLUMN],
+        keep="last",
+    )[["game_date", PARTICIPANT_JOIN_KEY_COLUMN, "strikeouts", "walks"]].copy()
+
+    pending_mask = (
+        working["game_date"].astype(str).eq(game_date)
+        & working.apply(_supports_statcast_history_row, axis=1)
+        & (
+            working["actual_value"].astype(str).str.strip().eq("")
+            | (
+                working["would_pick"].fillna(False)
+                & working["result"].astype(str).str.strip().eq("")
+            )
+        )
+    )
+    if not pending_mask.any():
+        return working
+
+    pending = working.loc[pending_mask].copy()
+    pending["shadow_row_index"] = pending.index
+    pending = pending.merge(
+        result_lookup,
+        on=["game_date", PARTICIPANT_JOIN_KEY_COLUMN],
+        how="left",
+    )
+    pending["statcast_result_column"] = pending.apply(_statcast_result_column_for_row, axis=1)
+    pending["actual_stat_value"] = pending.apply(
+        lambda row: row.get(str(row["statcast_result_column"]), pd.NA)
+        if row["statcast_result_column"]
+        else pd.NA,
+        axis=1,
+    )
+    resolved_mask = pd.to_numeric(pending["actual_stat_value"], errors="coerce").notna()
+    if not resolved_mask.any():
+        return working
+
+    pending.loc[resolved_mask, "actual_value"] = pending.loc[resolved_mask, "actual_stat_value"].apply(
+        _format_stat_value
+    )
+    actionable_mask = resolved_mask & pending["would_pick"].fillna(False)
+    pending.loc[actionable_mask, "result"] = pending.loc[actionable_mask].apply(
+        lambda row: _grade_pick_result_from_actual(
+            actual=float(row["actual_stat_value"]),
+            line=float(row["line"]),
+            pick_side=str(row["side"]),
+        ),
+        axis=1,
+    )
+    pending.loc[actionable_mask, "profit_units"] = pending.loc[actionable_mask].apply(
+        lambda row: _profit_units_for_result(
+            _resolve_history_row_odds(row),
+            _normalize_pick_result(row["result"]),
+        ),
+        axis=1,
+    )
+    graded_at = pd.Timestamp.now(tz="America/New_York").isoformat()
+    pending.loc[resolved_mask, "graded_at"] = graded_at
+
+    working.loc[pending["shadow_row_index"], pitcher_k_shadow.SHADOW_TRACKING_COLUMNS] = pending[
+        pitcher_k_shadow.SHADOW_TRACKING_COLUMNS
+    ].values
+    return pitcher_k_shadow.coerce_shadow_tracking_df(working)
+
+
+def grade_pitcher_k_shadow_predictions_from_statcast(
+    *,
+    game_date: str | None = None,
+) -> dict[str, object]:
+    target_date = game_date or _yesterday_game_date()
+    shadow_df = load_pitcher_k_shadow_tracking()
+    if shadow_df.empty:
+        return {"game_date": target_date, "updated_rows": 0, "shadow_df": shadow_df}
+
+    pending_mask = (
+        shadow_df["game_date"].astype(str).eq(target_date)
+        & shadow_df.apply(_supports_statcast_history_row, axis=1)
+        & (
+            shadow_df["actual_value"].astype(str).str.strip().eq("")
+            | (
+                shadow_df["would_pick"].fillna(False)
+                & shadow_df["result"].astype(str).str.strip().eq("")
+            )
+        )
+    )
+    if not pending_mask.any():
+        return {"game_date": target_date, "updated_rows": 0, "shadow_df": shadow_df}
+
+    pitcher_results_df = load_pitcher_results_from_statcast(target_date)
+    updated_shadow_df = apply_statcast_results_to_pitcher_k_shadow_tracking(
+        shadow_df,
+        pitcher_results_df,
+        game_date=target_date,
+    )
+    before = shadow_df["actual_value"].astype(str).str.strip()
+    after = updated_shadow_df["actual_value"].astype(str).str.strip()
+    updated_rows = int(((before == "") & (after != "")).sum())
+    updated_shadow_df.to_csv(PITCHER_K_SHADOW_TRACKING_PATH, index=False)
+    return {
+        "game_date": target_date,
+        "updated_rows": updated_rows,
+        "shadow_df": updated_shadow_df,
+    }
+
+
+def persist_pitcher_k_shadow_comparison_report() -> dict[str, object]:
+    shadow_df = load_pitcher_k_shadow_tracking()
+    report = pitcher_k_shadow.build_shadow_comparison_report(shadow_df)
+    overlap_df = report["overlap_df"]
+    overlap_df.to_csv(PITCHER_K_SHADOW_OVERLAP_PATH, index=False)
+
+    regression_written = False
+    workflow_written = False
+    if report.get("available"):
+        regression_written = pitcher_k_shadow.write_shadow_regression_plot(
+            report["daily_regression_df"],
+            PITCHER_K_SHADOW_REGRESSION_PLOT_PATH,
+        )
+        workflow_written = pitcher_k_shadow.write_shadow_workflow_plot(
+            report["daily_workflow_df"],
+            PITCHER_K_SHADOW_WORKFLOW_PLOT_PATH,
+        )
+
+    summary = dict(report["summary"])
+    summary["outputs"] = {
+        "tracking_csv": str(PITCHER_K_SHADOW_TRACKING_PATH),
+        "overlap_csv": str(PITCHER_K_SHADOW_OVERLAP_PATH),
+        "summary_json": str(PITCHER_K_SHADOW_SUMMARY_PATH),
+        "regression_plot": str(PITCHER_K_SHADOW_REGRESSION_PLOT_PATH) if regression_written else None,
+        "workflow_plot": str(PITCHER_K_SHADOW_WORKFLOW_PLOT_PATH) if workflow_written else None,
+    }
+    PITCHER_K_SHADOW_SUMMARY_PATH.write_text(json.dumps(summary, indent=2), encoding="utf-8")
+    return {
+        "summary": summary,
+        "overlap_df": overlap_df,
+        "regression_plot_written": regression_written,
+        "workflow_plot_written": workflow_written,
     }
 
 
@@ -1958,6 +2258,14 @@ def save_outputs(
             f"{_yesterday_game_date()}: {exc.__class__.__name__}: {exc}"
         )
         persist_official_picks_profit_reports()
+    try:
+        grade_pitcher_k_shadow_predictions_from_statcast()
+        persist_pitcher_k_shadow_comparison_report()
+    except Exception as exc:
+        print(
+            "WARNING: Failed to update pitcher_k shadow tracking for "
+            f"{_yesterday_game_date()}: {exc.__class__.__name__}: {exc}"
+        )
     save_run_status(status=run_status, message=run_message)
 
 
@@ -2197,6 +2505,23 @@ def run_workflow_daily_card(
             metadata=metadata,
             game_date=workflow_game_date,
         )
+
+    if workflow.prop_type == "pitcher_k":
+        try:
+            persist_pitcher_k_shadow_predictions(
+                starters_df=starters_df,
+                pitcher_games=history_df,
+                joined_df=joined_df,
+                picks_df=picks_df,
+                workflow=workflow,
+                metadata=metadata,
+                build_picks_fn=build_picks_fn,
+            )
+        except Exception as exc:
+            print(
+                "WARNING: Failed to persist pitcher_k shadow predictions for "
+                f"{workflow_game_date}: {exc.__class__.__name__}: {exc}"
+            )
 
     return today_preds, joined_df, picks_df, post_df, run_status, run_message
 

--- a/MLB/src/pitcher_k/shadow.py
+++ b/MLB/src/pitcher_k/shadow.py
@@ -1,0 +1,961 @@
+from __future__ import annotations
+
+import math
+from pathlib import Path
+
+import matplotlib.dates as mdates
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+
+from common.identity import (
+    MARKET_OFFER_KEY_COLUMN,
+    MARKET_SELECTION_KEY_COLUMN,
+    PARTICIPANT_ID_COLUMN,
+    PARTICIPANT_JOIN_KEY_COLUMN,
+    PARTICIPANT_NAME_NORM_COLUMN,
+    PARTICIPANT_SOURCE_ID_COLUMN,
+    PARTICIPANT_SOURCE_ID_TYPE_COLUMN,
+    ensure_market_identity,
+    ensure_participant_identity,
+)
+from pitcher_k import config
+from pitcher_k.evaluate import (
+    DEFAULT_INTERVAL_COVERAGE,
+    apply_interval_calibration,
+    evaluate_predictions,
+    fit_interval_calibration,
+)
+from pitcher_k.feature_engineering import filter_starter_like_appearances
+from pitcher_k.feature_model import build_model_df
+from pitcher_k.train import validation_time_split
+
+
+CHAMPION_MODEL_NAME = "xgboost_champion"
+CHALLENGER_MODEL_NAME = "ridge_challenger"
+CHAMPION_MODEL_ROLE = "champion"
+CHALLENGER_MODEL_ROLE = "challenger"
+RIDGE_ALPHA_CANDIDATES = (0.01, 0.1, 1.0, 10.0, 100.0)
+ROLLING_WINDOWS = (7, 14, 30)
+
+SHADOW_TRACKING_COLUMNS = [
+    "shadow_row_key",
+    "candidate_key",
+    "game_date",
+    "player_name",
+    PARTICIPANT_JOIN_KEY_COLUMN,
+    PARTICIPANT_ID_COLUMN,
+    PARTICIPANT_SOURCE_ID_COLUMN,
+    PARTICIPANT_SOURCE_ID_TYPE_COLUMN,
+    PARTICIPANT_NAME_NORM_COLUMN,
+    "sport",
+    "market_key",
+    "market_family",
+    "prop_type",
+    "team",
+    "opponent",
+    "book",
+    "bookmaker_key",
+    "event_id",
+    "side",
+    "side_norm",
+    "line",
+    "price",
+    MARKET_SELECTION_KEY_COLUMN,
+    MARKET_OFFER_KEY_COLUMN,
+    "model_name",
+    "model_role",
+    "model_version",
+    "policy_version",
+    "predicted_value",
+    "predicted_strikeouts",
+    "lower_bound",
+    "upper_bound",
+    "std_dev",
+    "edge",
+    "would_pick",
+    "pick_rank",
+    "pick_type",
+    "confidence_tier",
+    "actual_value",
+    "result",
+    "profit_units",
+    "graded_at",
+    "tracking_regime",
+]
+
+
+def empty_shadow_tracking_df() -> pd.DataFrame:
+    return pd.DataFrame(columns=SHADOW_TRACKING_COLUMNS)
+
+
+def _normalize_side(value: object) -> str:
+    if pd.isna(value):
+        return ""
+    return str(value).strip().lower()
+
+
+def _line_band(line: object) -> str:
+    numeric = pd.to_numeric(pd.Series([line]), errors="coerce").iloc[0]
+    if pd.isna(numeric):
+        return "unknown"
+    if float(numeric) <= 4.5:
+        return "<=4.5"
+    if float(numeric) <= 5.5:
+        return "4.5-5.5"
+    if float(numeric) <= 6.5:
+        return "5.5-6.5"
+    if float(numeric) <= 7.5:
+        return "6.5-7.5"
+    return "7.5+"
+
+
+def _first_present(df: pd.DataFrame, columns: list[str], default: object = "") -> pd.Series:
+    resolved = pd.Series([default] * len(df), index=df.index, dtype="object")
+    for column in columns:
+        if column not in df.columns:
+            continue
+        series = df[column]
+        if pd.api.types.is_numeric_dtype(series):
+            mask = series.notna()
+        else:
+            mask = series.fillna("").astype(str).str.strip().ne("")
+        resolved = resolved.where(~mask, series)
+    return resolved
+
+
+def _format_line_key(value: object) -> str:
+    if pd.isna(value):
+        return ""
+    try:
+        return f"{float(value):g}"
+    except (TypeError, ValueError):
+        return str(value).strip()
+
+
+def _fallback_candidate_key(
+    df: pd.DataFrame,
+    *,
+    book_col: str,
+    side_col: str,
+    line_col: str,
+) -> pd.Series:
+    player_key = _first_present(
+        df,
+        [PARTICIPANT_JOIN_KEY_COLUMN, PARTICIPANT_NAME_NORM_COLUMN, "player_name", "player_name_proj"],
+        "",
+    ).fillna("").astype(str).str.strip()
+    game_date = pd.to_datetime(_first_present(df, ["game_date"], "")).dt.strftime("%Y-%m-%d").fillna("")
+    book = _first_present(df, [book_col, "book", "bookmaker"], "").fillna("").astype(str).str.strip().str.lower()
+    side = _first_present(df, [side_col, "side", "pick_side"], "").apply(_normalize_side)
+    line = _first_present(df, [line_col, "line"], "").apply(_format_line_key)
+    return game_date + "|" + player_key + "|" + book + "|" + side + "|" + line
+
+
+def candidate_key_series(
+    df: pd.DataFrame,
+    *,
+    book_col: str,
+    side_col: str,
+    line_col: str,
+) -> pd.Series:
+    game_date = pd.to_datetime(_first_present(df, ["game_date"], ""), errors="coerce").dt.strftime("%Y-%m-%d").fillna("")
+    market_offer_key = _first_present(df, [MARKET_OFFER_KEY_COLUMN], "").fillna("").astype(str).str.strip()
+    fallback = _fallback_candidate_key(df, book_col=book_col, side_col=side_col, line_col=line_col)
+    base_key = market_offer_key.where(market_offer_key != "", fallback)
+    return game_date + "|" + base_key
+
+
+def shadow_row_key_series(df: pd.DataFrame, *, model_name_col: str = "model_name") -> pd.Series:
+    game_date = pd.to_datetime(_first_present(df, ["game_date"], "")).dt.strftime("%Y-%m-%d").fillna("")
+    model_name = _first_present(df, [model_name_col], "").fillna("").astype(str).str.strip()
+    candidate_key = _first_present(df, ["candidate_key"], "").fillna("").astype(str).str.strip()
+    return game_date + "|" + model_name + "|" + candidate_key
+
+
+def _ridge_solver(X_design: np.ndarray, y: np.ndarray, alpha: float) -> np.ndarray:
+    penalty = np.eye(X_design.shape[1], dtype=float)
+    penalty[0, 0] = 0.0
+    return np.linalg.solve(X_design.T @ X_design + alpha * penalty, X_design.T @ y)
+
+
+def _design_matrix(
+    df: pd.DataFrame,
+    features: list[str],
+    mu: np.ndarray,
+    sigma: np.ndarray,
+) -> np.ndarray:
+    X = df[features].to_numpy(dtype=float)
+    X_std = (X - mu) / sigma
+    return np.column_stack([np.ones(len(X_std)), X_std])
+
+
+def fit_ridge_shadow_model(
+    pitcher_games: pd.DataFrame,
+    *,
+    alpha_candidates: tuple[float, ...] = RIDGE_ALPHA_CANDIDATES,
+) -> dict[str, object]:
+    starter_like = filter_starter_like_appearances(pitcher_games)
+    model_df = build_model_df(starter_like)
+    if model_df.empty:
+        raise ValueError("pitcher_games did not produce any model rows for ridge shadow fitting.")
+
+    features = list(config.BASE_FEATURES)
+    subtrain_df, validation_df = validation_time_split(
+        model_df,
+        validation_fraction=config.TRAIN_VALIDATION_FRACTION,
+    )
+    if validation_df.empty:
+        subtrain_df = model_df.copy()
+        validation_df = model_df.copy()
+
+    X_sub = subtrain_df[features].to_numpy(dtype=float)
+    y_sub = subtrain_df[config.TARGET_COL].to_numpy(dtype=float)
+    X_val = validation_df[features].to_numpy(dtype=float)
+    y_val = validation_df[config.TARGET_COL].to_numpy(dtype=float)
+
+    mu = X_sub.mean(axis=0)
+    sigma = X_sub.std(axis=0)
+    sigma[sigma == 0] = 1.0
+    X_sub_design = _design_matrix(subtrain_df, features, mu, sigma)
+    X_val_design = _design_matrix(validation_df, features, mu, sigma)
+
+    best_alpha = None
+    best_metrics = None
+    best_validation_pred = None
+    for alpha in alpha_candidates:
+        coef = _ridge_solver(X_sub_design, y_sub, alpha)
+        validation_pred = np.clip(X_val_design @ coef, a_min=0.0, a_max=None)
+        metrics = evaluate_predictions(y_val, validation_pred)
+        if best_metrics is None or metrics["mae"] < best_metrics["mae"]:
+            best_alpha = float(alpha)
+            best_metrics = metrics
+            best_validation_pred = validation_pred
+
+    X_full = model_df[features].to_numpy(dtype=float)
+    y_full = model_df[config.TARGET_COL].to_numpy(dtype=float)
+    mu_full = X_full.mean(axis=0)
+    sigma_full = X_full.std(axis=0)
+    sigma_full[sigma_full == 0] = 1.0
+    X_full_design = _design_matrix(model_df, features, mu_full, sigma_full)
+    coef_full = _ridge_solver(X_full_design, y_full, best_alpha or 0.0)
+
+    interval_config = fit_interval_calibration(
+        validation_df,
+        y_val,
+        best_validation_pred if best_validation_pred is not None else np.clip(X_val_design @ coef_full, a_min=0.0, a_max=None),
+    )
+
+    return {
+        "features": features,
+        "alpha": float(best_alpha or 0.0),
+        "coefficients": coef_full,
+        "mu": mu_full,
+        "sigma": sigma_full,
+        "interval_config": interval_config,
+        "training_rows": int(len(model_df)),
+        "validation_rows": int(len(validation_df)),
+        "validation_metrics": best_metrics or {},
+    }
+
+
+def predict_ridge_shadow_model(
+    today_features: pd.DataFrame,
+    fitted_model: dict[str, object],
+) -> pd.DataFrame:
+    if today_features.empty:
+        return today_features.copy()
+
+    features = list(fitted_model["features"])
+    mu = np.asarray(fitted_model["mu"], dtype=float)
+    sigma = np.asarray(fitted_model["sigma"], dtype=float)
+    coefficients = np.asarray(fitted_model["coefficients"], dtype=float)
+
+    pred_df = today_features.copy()
+    X_design = _design_matrix(pred_df, features, mu, sigma)
+    pred_df["predicted_strikeouts"] = np.clip(X_design @ coefficients, a_min=0.0, a_max=None)
+    pred_df["predicted_value"] = pred_df["predicted_strikeouts"]
+    pred_df = apply_interval_calibration(pred_df, fitted_model.get("interval_config"))
+    return pred_df
+
+
+def build_ridge_shadow_predictions(
+    today_features: pd.DataFrame,
+    pitcher_games: pd.DataFrame,
+) -> tuple[pd.DataFrame, dict[str, object]]:
+    fitted = fit_ridge_shadow_model(pitcher_games)
+    pred_df = predict_ridge_shadow_model(today_features, fitted)
+    challenger_version = f"{config.TARGET_FORMULATION}_ridge_shadow_alpha_{fitted['alpha']:g}"
+    fitted_meta = {
+        "model_name": CHALLENGER_MODEL_NAME,
+        "model_role": CHALLENGER_MODEL_ROLE,
+        "model_version": challenger_version,
+        "selected_alpha": float(fitted["alpha"]),
+        "interval_config": fitted.get("interval_config", {}),
+        "training_rows": int(fitted.get("training_rows", 0)),
+        "validation_rows": int(fitted.get("validation_rows", 0)),
+        "validation_metrics": fitted.get("validation_metrics", {}),
+    }
+    return pred_df, fitted_meta
+
+
+def apply_prediction_frame_to_joined_rows(
+    joined_df: pd.DataFrame,
+    prediction_df: pd.DataFrame,
+    *,
+    prediction_column: str = "predicted_value",
+    prop_prediction_column: str = "predicted_strikeouts",
+) -> pd.DataFrame:
+    if joined_df.empty:
+        return joined_df.copy()
+
+    preds = prediction_df.copy()
+    preds = ensure_participant_identity(
+        preds,
+        display_name_col="player_name",
+        normalized_name_col=PARTICIPANT_NAME_NORM_COLUMN if PARTICIPANT_NAME_NORM_COLUMN in preds.columns else None,
+        source_id_col="pitcher" if "pitcher" in preds.columns else PARTICIPANT_SOURCE_ID_COLUMN,
+        source_id_type="mlbam_player",
+    )
+    preds = ensure_market_identity(
+        preds,
+        sport="MLB",
+        market_key=config.PITCHER_K_PROP_MARKET,
+    )
+
+    mapping_columns = [
+        PARTICIPANT_JOIN_KEY_COLUMN,
+        prop_prediction_column,
+        prediction_column,
+        "lower_bound",
+        "upper_bound",
+        "std_dev",
+    ]
+    preds = preds[[column for column in mapping_columns if column in preds.columns]].drop_duplicates(
+        subset=[PARTICIPANT_JOIN_KEY_COLUMN],
+        keep="last",
+    )
+
+    working = joined_df.copy()
+    working = ensure_participant_identity(
+        working,
+        display_name_col="player_name" if "player_name" in working.columns else "player_name_proj",
+        normalized_name_col=PARTICIPANT_NAME_NORM_COLUMN if PARTICIPANT_NAME_NORM_COLUMN in working.columns else None,
+    )
+    merged = working.drop(
+        columns=[
+            column
+            for column in [prediction_column, prop_prediction_column, "lower_bound", "upper_bound", "std_dev"]
+            if column in working.columns
+        ]
+    ).merge(
+        preds,
+        on=PARTICIPANT_JOIN_KEY_COLUMN,
+        how="left",
+    )
+    if prediction_column not in merged.columns and prop_prediction_column in merged.columns:
+        merged[prediction_column] = merged[prop_prediction_column]
+    return merged
+
+
+def side_relative_edge(predicted_value: object, line: object, side: object) -> float | None:
+    predicted_numeric = pd.to_numeric(pd.Series([predicted_value]), errors="coerce").iloc[0]
+    line_numeric = pd.to_numeric(pd.Series([line]), errors="coerce").iloc[0]
+    if pd.isna(predicted_numeric) or pd.isna(line_numeric):
+        return None
+    side_norm = _normalize_side(side)
+    if side_norm == "under":
+        return float(line_numeric - predicted_numeric)
+    return float(predicted_numeric - line_numeric)
+
+
+def build_shadow_candidate_rows(
+    joined_df: pd.DataFrame,
+    picks_df: pd.DataFrame,
+    *,
+    model_name: str,
+    model_role: str,
+    model_version: str,
+    policy_version: str,
+    tracking_regime: str,
+    game_date: object,
+) -> pd.DataFrame:
+    if joined_df.empty:
+        return empty_shadow_tracking_df()
+
+    working = joined_df.copy()
+    working = ensure_participant_identity(
+        working,
+        display_name_col="player_name" if "player_name" in working.columns else "player_name_proj",
+        normalized_name_col=PARTICIPANT_NAME_NORM_COLUMN if PARTICIPANT_NAME_NORM_COLUMN in working.columns else None,
+        source_id_col=PARTICIPANT_SOURCE_ID_COLUMN if PARTICIPANT_SOURCE_ID_COLUMN in working.columns else None,
+        source_id_type="mlbam_player",
+    )
+    working = ensure_market_identity(
+        working,
+        sport="MLB",
+        market_key=config.PITCHER_K_PROP_MARKET,
+    )
+
+    resolved_game_date = pd.to_datetime(
+        _first_present(working, ["game_date"], game_date),
+        errors="coerce",
+    ).dt.strftime("%Y-%m-%d")
+    working["game_date"] = resolved_game_date
+    working["player_name"] = _first_present(working, ["player_name", "player_name_proj"], "").fillna("").astype(str)
+    working["book"] = _first_present(working, ["book", "bookmaker"], "").fillna("").astype(str)
+    working["bookmaker_key"] = _first_present(working, ["bookmaker_key"], "").fillna("").astype(str)
+    working["event_id"] = _first_present(working, ["event_id"], "").fillna("").astype(str)
+    working["side"] = _first_present(working, ["side"], "").fillna("").astype(str)
+    working["side_norm"] = working["side"].apply(_normalize_side)
+    working["line"] = pd.to_numeric(_first_present(working, ["line"], np.nan), errors="coerce")
+    working["price"] = pd.to_numeric(_first_present(working, ["price"], np.nan), errors="coerce")
+    working["team"] = _first_present(working, ["team"], "").fillna("").astype(str)
+    working["opponent"] = _first_present(working, ["opponent"], "").fillna("").astype(str)
+    working["predicted_strikeouts"] = pd.to_numeric(
+        _first_present(working, ["predicted_strikeouts", "predicted_value"], np.nan),
+        errors="coerce",
+    )
+    working["predicted_value"] = pd.to_numeric(
+        _first_present(working, ["predicted_value", "predicted_strikeouts"], np.nan),
+        errors="coerce",
+    )
+    working["lower_bound"] = pd.to_numeric(_first_present(working, ["lower_bound"], np.nan), errors="coerce")
+    working["upper_bound"] = pd.to_numeric(_first_present(working, ["upper_bound"], np.nan), errors="coerce")
+    working["std_dev"] = pd.to_numeric(_first_present(working, ["std_dev"], np.nan), errors="coerce")
+    working["candidate_key"] = candidate_key_series(
+        working,
+        book_col="book",
+        side_col="side",
+        line_col="line",
+    )
+    working["edge"] = working.apply(
+        lambda row: side_relative_edge(row["predicted_value"], row["line"], row["side"]),
+        axis=1,
+    )
+    working["model_name"] = model_name
+    working["model_role"] = model_role
+    working["model_version"] = model_version
+    working["policy_version"] = policy_version
+    working["tracking_regime"] = tracking_regime
+    working["prop_type"] = "pitcher_k"
+
+    pick_lookup = pd.DataFrame(columns=["candidate_key", "would_pick", "pick_rank", "pick_type", "confidence_tier"])
+    if not picks_df.empty:
+        actionable = picks_df.copy()
+        actionable = actionable[actionable["pick_type"].astype(str).ne("pass")].copy()
+        if not actionable.empty:
+            actionable["game_date"] = pd.to_datetime(
+                _first_present(actionable, ["game_date"], game_date),
+                errors="coerce",
+            ).dt.strftime("%Y-%m-%d")
+            actionable["candidate_key"] = candidate_key_series(
+                actionable,
+                book_col="book",
+                side_col="pick_side",
+                line_col="line",
+            )
+            actionable = actionable.reset_index(drop=True)
+            actionable["would_pick"] = True
+            actionable["pick_rank"] = actionable.index + 1
+            pick_lookup = actionable[
+                ["candidate_key", "would_pick", "pick_rank", "pick_type", "confidence_tier"]
+            ].drop_duplicates(subset=["candidate_key"], keep="first")
+
+    working = working.merge(
+        pick_lookup,
+        on="candidate_key",
+        how="left",
+    )
+    working["would_pick"] = working["would_pick"].fillna(False).astype(bool)
+    working["pick_rank"] = pd.to_numeric(working["pick_rank"], errors="coerce")
+    working["pick_type"] = working["pick_type"].fillna("").astype(str)
+    working["confidence_tier"] = working["confidence_tier"].fillna("").astype(str)
+    working["actual_value"] = ""
+    working["result"] = ""
+    working["profit_units"] = pd.NA
+    working["graded_at"] = ""
+    working["shadow_row_key"] = shadow_row_key_series(working)
+
+    for column in SHADOW_TRACKING_COLUMNS:
+        if column not in working.columns:
+            if column in {"profit_units", "pick_rank", "line", "price", "predicted_value", "predicted_strikeouts", "lower_bound", "upper_bound", "std_dev", "edge"}:
+                working[column] = pd.NA
+            elif column == "would_pick":
+                working[column] = False
+            else:
+                working[column] = ""
+
+    return working[SHADOW_TRACKING_COLUMNS].copy()
+
+
+def coerce_shadow_tracking_df(df: pd.DataFrame) -> pd.DataFrame:
+    if df.empty:
+        return empty_shadow_tracking_df()
+
+    working = df.copy()
+    for column in SHADOW_TRACKING_COLUMNS:
+        if column not in working.columns:
+            working[column] = pd.NA if column in {"profit_units", "pick_rank"} else ""
+
+    numeric_columns = [
+        "line",
+        "price",
+        "predicted_value",
+        "predicted_strikeouts",
+        "lower_bound",
+        "upper_bound",
+        "std_dev",
+        "edge",
+        "pick_rank",
+        "profit_units",
+    ]
+    for column in numeric_columns:
+        working[column] = pd.to_numeric(working[column], errors="coerce")
+
+    bool_series = working["would_pick"]
+    if bool_series.dtype != bool:
+        working["would_pick"] = bool_series.astype(str).str.strip().str.lower().isin(["true", "1", "yes"])
+    working["game_date"] = pd.to_datetime(working["game_date"], errors="coerce").dt.strftime("%Y-%m-%d")
+    return working[SHADOW_TRACKING_COLUMNS].copy()
+
+
+def build_shadow_overlap_df(
+    shadow_df: pd.DataFrame,
+    *,
+    required_models: tuple[str, ...] = (CHAMPION_MODEL_NAME, CHALLENGER_MODEL_NAME),
+) -> pd.DataFrame:
+    working = coerce_shadow_tracking_df(shadow_df)
+    if working.empty:
+        return empty_shadow_tracking_df()
+
+    actual_numeric = pd.to_numeric(working["actual_value"], errors="coerce")
+    working = working[actual_numeric.notna()].copy()
+    if working.empty:
+        return empty_shadow_tracking_df()
+
+    overlap_keys = (
+        working.groupby("candidate_key")["model_name"]
+        .nunique()
+        .reset_index(name="model_count")
+    )
+    overlap_keys = overlap_keys[overlap_keys["model_count"] >= len(required_models)]["candidate_key"]
+    if overlap_keys.empty:
+        return empty_shadow_tracking_df()
+
+    overlap = working[working["candidate_key"].isin(set(overlap_keys))].copy()
+    overlap = overlap.sort_values(["game_date", "candidate_key", "model_name"]).reset_index(drop=True)
+    return overlap[SHADOW_TRACKING_COLUMNS].copy()
+
+
+def _prediction_level_df(overlap_df: pd.DataFrame) -> pd.DataFrame:
+    if overlap_df.empty:
+        return empty_shadow_tracking_df()
+    working = overlap_df.copy()
+    working["actual_numeric"] = pd.to_numeric(working["actual_value"], errors="coerce")
+    working = working.drop_duplicates(
+        subset=["game_date", PARTICIPANT_JOIN_KEY_COLUMN, "model_name"],
+        keep="first",
+    ).reset_index(drop=True)
+    return working
+
+
+def _workflow_pick_df(overlap_df: pd.DataFrame) -> pd.DataFrame:
+    if overlap_df.empty:
+        return empty_shadow_tracking_df()
+    working = overlap_df.copy()
+    working["result_normalized"] = working["result"].fillna("").astype(str).str.strip()
+    working["profit_units"] = pd.to_numeric(working["profit_units"], errors="coerce")
+    return working[working["would_pick"]].copy()
+
+
+def _build_group_summary(df: pd.DataFrame, *, group_column: str | None = None) -> list[dict[str, object]]:
+    if df.empty:
+        return []
+
+    working = df.copy()
+    working["profit_units"] = pd.to_numeric(working["profit_units"], errors="coerce").fillna(0.0)
+    working["wins"] = working["result_normalized"].eq("W").astype(int)
+    working["losses"] = working["result_normalized"].eq("L").astype(int)
+    working["pushes"] = working["result_normalized"].eq("Push").astype(int)
+    if group_column is None:
+        working["_overall"] = "overall"
+        group_column = "_overall"
+
+    summary = (
+        working.groupby(group_column, dropna=False)
+        .agg(
+            picks=("candidate_key", "size"),
+            wins=("wins", "sum"),
+            losses=("losses", "sum"),
+            pushes=("pushes", "sum"),
+            profit_units=("profit_units", "sum"),
+        )
+        .reset_index()
+    )
+    summary["win_rate"] = summary.apply(
+        lambda row: row["wins"] / (row["wins"] + row["losses"]) if (row["wins"] + row["losses"]) else None,
+        axis=1,
+    )
+    summary["roi_per_pick"] = summary.apply(
+        lambda row: row["profit_units"] / row["picks"] if row["picks"] else None,
+        axis=1,
+    )
+
+    records = summary.to_dict(orient="records")
+    for record in records:
+        if "_overall" in record:
+            record.pop("_overall", None)
+        for key, value in list(record.items()):
+            if isinstance(value, (np.floating, float)) and math.isnan(value):
+                record[key] = None
+    return records
+
+
+def _build_agreement_summary(
+    overlap_df: pd.DataFrame,
+    *,
+    required_models: tuple[str, ...],
+) -> list[dict[str, object]]:
+    picked = _workflow_pick_df(overlap_df)
+    if picked.empty or len(required_models) < 2:
+        return []
+
+    pair_base = overlap_df[
+        ["game_date", PARTICIPANT_JOIN_KEY_COLUMN, "player_name"]
+    ].drop_duplicates(
+        subset=["game_date", PARTICIPANT_JOIN_KEY_COLUMN],
+        keep="first",
+    )
+
+    champion_name, challenger_name = required_models[:2]
+    model_frames: list[pd.DataFrame] = []
+    for model_name in [champion_name, challenger_name]:
+        model_df = picked[picked["model_name"] == model_name].copy()
+        model_df = model_df[
+            [
+                "game_date",
+                PARTICIPANT_JOIN_KEY_COLUMN,
+                "candidate_key",
+                "result_normalized",
+                "profit_units",
+            ]
+        ].rename(
+            columns={
+                "candidate_key": f"{model_name}_candidate_key",
+                "result_normalized": f"{model_name}_result",
+                "profit_units": f"{model_name}_profit_units",
+            }
+        )
+        model_frames.append(model_df)
+
+    pair_df = pair_base.copy()
+    for model_df in model_frames:
+        pair_df = pair_df.merge(
+            model_df,
+            on=["game_date", PARTICIPANT_JOIN_KEY_COLUMN],
+            how="left",
+        )
+
+    pair_df["comparison_slice"] = np.where(
+        pair_df[f"{champion_name}_candidate_key"].notna()
+        & pair_df[f"{challenger_name}_candidate_key"].notna()
+        & pair_df[f"{champion_name}_candidate_key"].eq(pair_df[f"{challenger_name}_candidate_key"]),
+        "agreement",
+        "disagreement",
+    )
+
+    records: list[dict[str, object]] = []
+    for slice_name, group in pair_df.groupby("comparison_slice", dropna=False):
+        record: dict[str, object] = {
+            "comparison_slice": slice_name,
+            "rows": int(len(group)),
+        }
+        for model_name in [champion_name, challenger_name]:
+            result_col = f"{model_name}_result"
+            profit_col = f"{model_name}_profit_units"
+            model_picks = group[result_col].notna().sum()
+            wins = int(group[result_col].eq("W").sum())
+            losses = int(group[result_col].eq("L").sum())
+            profits = float(pd.to_numeric(group[profit_col], errors="coerce").fillna(0.0).sum())
+            record[f"{model_name}_picks"] = int(model_picks)
+            record[f"{model_name}_wins"] = wins
+            record[f"{model_name}_losses"] = losses
+            record[f"{model_name}_profit_units"] = profits
+            record[f"{model_name}_roi_per_pick"] = (profits / model_picks) if model_picks else None
+        records.append(record)
+    return records
+
+
+def _build_daily_regression_summary(prediction_df: pd.DataFrame) -> pd.DataFrame:
+    records: list[dict[str, object]] = []
+    for (game_date, model_name), group in prediction_df.groupby(["game_date", "model_name"], dropna=False):
+        metrics = evaluate_predictions(
+            pd.to_numeric(group["actual_numeric"], errors="coerce"),
+            pd.to_numeric(group["predicted_value"], errors="coerce"),
+        )
+        nominal = float(group.get("interval_coverage_target", pd.Series([DEFAULT_INTERVAL_COVERAGE])).dropna().iloc[0]) if "interval_coverage_target" in group.columns and not group["interval_coverage_target"].dropna().empty else DEFAULT_INTERVAL_COVERAGE
+        within_bounds = (
+            pd.to_numeric(group["actual_numeric"], errors="coerce").between(
+                pd.to_numeric(group["lower_bound"], errors="coerce"),
+                pd.to_numeric(group["upper_bound"], errors="coerce"),
+                inclusive="both",
+            )
+        )
+        records.append(
+            {
+                "game_date": game_date,
+                "model_name": model_name,
+                "rows": int(len(group)),
+                "mae": float(metrics["mae"]),
+                "rmse": float(metrics["rmse"]),
+                "nominal_coverage": nominal,
+                "empirical_coverage": float(within_bounds.mean()),
+                "calibration_gap": abs(float(within_bounds.mean()) - nominal),
+            }
+        )
+    return pd.DataFrame(records)
+
+
+def _build_daily_workflow_summary(picked_df: pd.DataFrame) -> pd.DataFrame:
+    if picked_df.empty:
+        return pd.DataFrame(
+            columns=["game_date", "model_name", "picks", "wins", "losses", "pushes", "profit_units", "roi_per_pick"]
+        )
+
+    working = picked_df.copy()
+    working["profit_units"] = pd.to_numeric(working["profit_units"], errors="coerce").fillna(0.0)
+    working["wins"] = working["result_normalized"].eq("W").astype(int)
+    working["losses"] = working["result_normalized"].eq("L").astype(int)
+    working["pushes"] = working["result_normalized"].eq("Push").astype(int)
+    summary = (
+        working.groupby(["game_date", "model_name"], dropna=False)
+        .agg(
+            picks=("candidate_key", "size"),
+            wins=("wins", "sum"),
+            losses=("losses", "sum"),
+            pushes=("pushes", "sum"),
+            profit_units=("profit_units", "sum"),
+        )
+        .reset_index()
+    )
+    summary["roi_per_pick"] = summary.apply(
+        lambda row: row["profit_units"] / row["picks"] if row["picks"] else None,
+        axis=1,
+    )
+    return summary
+
+
+def _latest_rolling_window_summary(
+    daily_df: pd.DataFrame,
+    *,
+    value_columns: list[str],
+) -> dict[str, dict[str, dict[str, object]]]:
+    if daily_df.empty:
+        return {}
+
+    daily_df = daily_df.copy()
+    daily_df["game_date"] = pd.to_datetime(daily_df["game_date"], errors="coerce")
+    latest_date = daily_df["game_date"].max()
+    payload: dict[str, dict[str, dict[str, object]]] = {}
+    for window in ROLLING_WINDOWS:
+        window_start = latest_date - pd.Timedelta(days=window - 1)
+        window_df = daily_df[daily_df["game_date"] >= window_start].copy()
+        window_payload: dict[str, dict[str, object]] = {}
+        for model_name, group in window_df.groupby("model_name", dropna=False):
+            record = {
+                "window_days": int(window),
+                "window_start": window_start.strftime("%Y-%m-%d"),
+                "window_end": latest_date.strftime("%Y-%m-%d"),
+                "days_with_data": int(group["game_date"].nunique()),
+            }
+            for column in value_columns:
+                if column in group.columns:
+                    record[f"mean_{column}"] = float(pd.to_numeric(group[column], errors="coerce").mean())
+            if "picks" in group.columns:
+                record["total_picks"] = int(pd.to_numeric(group["picks"], errors="coerce").sum())
+            window_payload[str(model_name)] = record
+        payload[str(window)] = window_payload
+    return payload
+
+
+def build_shadow_comparison_report(
+    shadow_df: pd.DataFrame,
+    *,
+    required_models: tuple[str, ...] = (CHAMPION_MODEL_NAME, CHALLENGER_MODEL_NAME),
+) -> dict[str, object]:
+    overlap_df = build_shadow_overlap_df(shadow_df, required_models=required_models)
+    if overlap_df.empty:
+        return {
+            "available": False,
+            "reason": "no_graded_overlapping_shadow_rows",
+            "overlap_df": empty_shadow_tracking_df(),
+            "daily_regression_df": pd.DataFrame(),
+            "daily_workflow_df": pd.DataFrame(),
+            "summary": {
+                "analysis_type": "pitcher_k_shadow_comparison",
+                "available": False,
+                "required_models": list(required_models),
+            },
+        }
+
+    prediction_df = _prediction_level_df(overlap_df)
+    picked_df = _workflow_pick_df(overlap_df)
+    picked_df["result_normalized"] = picked_df["result"].fillna("").astype(str).str.strip()
+    picked_df["line_band"] = picked_df["line"].apply(_line_band)
+
+    model_summaries: dict[str, dict[str, object]] = {}
+    for model_name, group in prediction_df.groupby("model_name", dropna=False):
+        metrics = evaluate_predictions(
+            pd.to_numeric(group["actual_numeric"], errors="coerce"),
+            pd.to_numeric(group["predicted_value"], errors="coerce"),
+        )
+        nominal = float(group.get("interval_coverage_target", pd.Series([DEFAULT_INTERVAL_COVERAGE])).dropna().iloc[0]) if "interval_coverage_target" in group.columns and not group["interval_coverage_target"].dropna().empty else DEFAULT_INTERVAL_COVERAGE
+        within_bounds = pd.to_numeric(group["actual_numeric"], errors="coerce").between(
+            pd.to_numeric(group["lower_bound"], errors="coerce"),
+            pd.to_numeric(group["upper_bound"], errors="coerce"),
+            inclusive="both",
+        )
+        workflow_group = picked_df[picked_df["model_name"] == model_name].copy()
+        workflow_summary = _build_group_summary(workflow_group)
+        workflow_overall = workflow_summary[0] if workflow_summary else {
+            "picks": 0,
+            "wins": 0,
+            "losses": 0,
+            "pushes": 0,
+            "profit_units": 0.0,
+            "win_rate": None,
+            "roi_per_pick": None,
+        }
+        model_summaries[str(model_name)] = {
+            "prediction_rows": int(len(group)),
+            "mae": float(metrics["mae"]),
+            "rmse": float(metrics["rmse"]),
+            "calibration_nominal_coverage": nominal,
+            "calibration_empirical_coverage": float(within_bounds.mean()),
+            "calibration_gap": abs(float(within_bounds.mean()) - nominal),
+            "pick_count": int(workflow_overall.get("picks", 0) or 0),
+            "wins": int(workflow_overall.get("wins", 0) or 0),
+            "losses": int(workflow_overall.get("losses", 0) or 0),
+            "profit_units": float(workflow_overall.get("profit_units", 0.0) or 0.0),
+            "win_rate": workflow_overall.get("win_rate"),
+            "roi_per_pick": workflow_overall.get("roi_per_pick"),
+        }
+
+    daily_regression_df = _build_daily_regression_summary(prediction_df)
+    daily_workflow_df = _build_daily_workflow_summary(picked_df)
+
+    summary = {
+        "analysis_type": "pitcher_k_shadow_comparison",
+        "available": True,
+        "required_models": list(required_models),
+        "date_range": {
+            "start_date": str(prediction_df["game_date"].min()),
+            "end_date": str(prediction_df["game_date"].max()),
+        },
+        "overlap_sample": {
+            "candidate_rows": int(len(overlap_df)),
+            "prediction_rows": int(len(prediction_df)),
+            "workflow_rows": int(len(picked_df)),
+            "unique_dates": int(prediction_df["game_date"].nunique()),
+        },
+        "models": model_summaries,
+        "agreement_slices": _build_agreement_summary(overlap_df, required_models=required_models),
+        "by_book": [
+            {
+                "model_name": model_name,
+                "groups": _build_group_summary(group, group_column="book"),
+            }
+            for model_name, group in picked_df.groupby("model_name", dropna=False)
+        ],
+        "by_line_band": [
+            {
+                "model_name": model_name,
+                "groups": _build_group_summary(group, group_column="line_band"),
+            }
+            for model_name, group in picked_df.groupby("model_name", dropna=False)
+        ],
+        "rolling_regression_windows": _latest_rolling_window_summary(
+            daily_regression_df,
+            value_columns=["mae", "rmse", "calibration_gap"],
+        ),
+        "rolling_workflow_windows": _latest_rolling_window_summary(
+            daily_workflow_df,
+            value_columns=["roi_per_pick", "profit_units"],
+        ),
+    }
+    return {
+        "available": True,
+        "reason": None,
+        "overlap_df": overlap_df,
+        "daily_regression_df": daily_regression_df,
+        "daily_workflow_df": daily_workflow_df,
+        "summary": summary,
+    }
+
+
+def write_shadow_regression_plot(
+    daily_regression_df: pd.DataFrame,
+    output_path: Path,
+) -> bool:
+    if daily_regression_df.empty:
+        return False
+
+    plot_df = daily_regression_df.copy()
+    plot_df["game_date"] = pd.to_datetime(plot_df["game_date"], errors="coerce")
+    fig, axes = plt.subplots(2, 1, figsize=(13, 8), sharex=True)
+
+    for model_name, group in plot_df.groupby("model_name", dropna=False):
+        group = group.sort_values("game_date").copy()
+        group["rolling_mae"] = group["mae"].rolling(window=7, min_periods=1).mean()
+        group["rolling_rmse"] = group["rmse"].rolling(window=7, min_periods=1).mean()
+        axes[0].plot(group["game_date"], group["rolling_mae"], marker="o", label=str(model_name))
+        axes[1].plot(group["game_date"], group["rolling_rmse"], marker="o", label=str(model_name))
+
+    axes[0].set_title("Pitcher K Shadow Regression Performance (7-day rolling)")
+    axes[0].set_ylabel("Rolling MAE")
+    axes[1].set_ylabel("Rolling RMSE")
+    axes[1].set_xlabel("Game date")
+    for ax in axes:
+        ax.grid(alpha=0.3)
+        ax.legend(loc="best")
+        ax.xaxis.set_major_formatter(mdates.DateFormatter("%Y-%m-%d"))
+    axes[1].tick_params(axis="x", rotation=45)
+    fig.tight_layout()
+    fig.savefig(output_path, dpi=160, bbox_inches="tight")
+    plt.close(fig)
+    return True
+
+
+def write_shadow_workflow_plot(
+    daily_workflow_df: pd.DataFrame,
+    output_path: Path,
+) -> bool:
+    if daily_workflow_df.empty:
+        return False
+
+    plot_df = daily_workflow_df.copy()
+    plot_df["game_date"] = pd.to_datetime(plot_df["game_date"], errors="coerce")
+    fig, axes = plt.subplots(2, 1, figsize=(13, 8), sharex=True)
+
+    for model_name, group in plot_df.groupby("model_name", dropna=False):
+        group = group.sort_values("game_date").copy()
+        group["cumulative_units"] = group["profit_units"].cumsum()
+        group["rolling_roi"] = group["roi_per_pick"].rolling(window=7, min_periods=1).mean()
+        axes[0].plot(group["game_date"], group["cumulative_units"], marker="o", label=str(model_name))
+        axes[1].plot(group["game_date"], group["rolling_roi"], marker="o", label=str(model_name))
+
+    axes[0].axhline(0.0, color="black", linewidth=1, linestyle="--")
+    axes[0].set_title("Pitcher K Shadow Workflow ROI (7-day rolling)")
+    axes[0].set_ylabel("Cumulative profit units")
+    axes[1].set_ylabel("Rolling ROI per pick")
+    axes[1].set_xlabel("Game date")
+    for ax in axes:
+        ax.grid(alpha=0.3)
+        ax.legend(loc="best")
+        ax.xaxis.set_major_formatter(mdates.DateFormatter("%Y-%m-%d"))
+    axes[1].tick_params(axis="x", rotation=45)
+    fig.tight_layout()
+    fig.savefig(output_path, dpi=160, bbox_inches="tight")
+    plt.close(fig)
+    return True

--- a/MLB/tests/conftest.py
+++ b/MLB/tests/conftest.py
@@ -95,4 +95,29 @@ def isolate_tracking_artifacts(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) 
         "OFFICIAL_PICKS_CONCENTRATION_AUDIT_PATH",
         tracking_dir / "official_picks_concentration_audit.json",
     )
+    monkeypatch.setattr(
+        daily_card,
+        "PITCHER_K_SHADOW_TRACKING_PATH",
+        tracking_dir / "pitcher_k_shadow_predictions.csv",
+    )
+    monkeypatch.setattr(
+        daily_card,
+        "PITCHER_K_SHADOW_OVERLAP_PATH",
+        tracking_dir / "pitcher_k_shadow_overlap.csv",
+    )
+    monkeypatch.setattr(
+        daily_card,
+        "PITCHER_K_SHADOW_SUMMARY_PATH",
+        tracking_dir / "pitcher_k_shadow_summary.json",
+    )
+    monkeypatch.setattr(
+        daily_card,
+        "PITCHER_K_SHADOW_REGRESSION_PLOT_PATH",
+        tracking_dir / "pitcher_k_shadow_regression.png",
+    )
+    monkeypatch.setattr(
+        daily_card,
+        "PITCHER_K_SHADOW_WORKFLOW_PLOT_PATH",
+        tracking_dir / "pitcher_k_shadow_workflow.png",
+    )
     return tracking_dir

--- a/MLB/tests/jobs/test_run_daily_card.py
+++ b/MLB/tests/jobs/test_run_daily_card.py
@@ -28,6 +28,11 @@ def test_tracking_artifact_paths_are_isolated_from_committed_repo_files(tmp_path
     assert committed_tracking_dir not in daily_card.OFFICIAL_PICKS_CURRENT_REGIME_SUMMARY_PATH.parents
     assert committed_tracking_dir not in daily_card.OFFICIAL_PICKS_SKIPPED_PATH.parents
     assert committed_tracking_dir not in daily_card.OFFICIAL_PICKS_CONCENTRATION_AUDIT_PATH.parents
+    assert committed_tracking_dir not in daily_card.PITCHER_K_SHADOW_TRACKING_PATH.parents
+    assert committed_tracking_dir not in daily_card.PITCHER_K_SHADOW_OVERLAP_PATH.parents
+    assert committed_tracking_dir not in daily_card.PITCHER_K_SHADOW_SUMMARY_PATH.parents
+    assert committed_tracking_dir not in daily_card.PITCHER_K_SHADOW_REGRESSION_PLOT_PATH.parents
+    assert committed_tracking_dir not in daily_card.PITCHER_K_SHADOW_WORKFLOW_PLOT_PATH.parents
 
 
 def test_run_daily_card_writes_outputs_with_mocked_dependencies(monkeypatch, tmp_path):

--- a/MLB/tests/jobs/test_run_daily_card_shadow.py
+++ b/MLB/tests/jobs/test_run_daily_card_shadow.py
@@ -1,0 +1,327 @@
+import json
+from dataclasses import replace
+
+import pandas as pd
+
+from common.identity import MARKET_OFFER_KEY_COLUMN, MARKET_SELECTION_KEY_COLUMN
+from jobs import run_daily_card as daily_card
+from pitcher_k.workflow import MLB_PITCHER_STRIKEOUT_WORKFLOW
+
+
+def test_persist_pitcher_k_shadow_predictions_writes_champion_and_challenger_rows(monkeypatch):
+    starters_df = pd.DataFrame(
+        [
+            {
+                "game_date": "2026-05-10",
+                "game_pk": 1,
+                "pitcher": 123,
+                "player_name": "Jacob deGrom",
+                "team": "TEX",
+                "opponent": "SEA",
+                "home_team": "TEX",
+                "away_team": "SEA",
+                "is_home": 1,
+                "p_throws": "R",
+            }
+        ]
+    )
+    pitcher_games = pd.DataFrame(
+        [
+            {
+                "game_date": "2026-05-09",
+                "game_pk": 99,
+                "pitcher": 123,
+                "player_name": "Jacob deGrom",
+                "pitching_team": "TEX",
+                "opponent_team": "SEA",
+                "strikeouts": 7,
+                "pitches_last10": 95,
+                "whiff_per_pitch_last3": 0.14,
+                "pitches_trend_last3_vs_last10": 2.0,
+                "avg_velo_last3": 97.5,
+                "avg_spin_last3": 2480.0,
+                "k_rate_last10": 0.31,
+                "pitches_per_batter_last10": 3.9,
+                "opp_strikeouts_per_game_last10": 9.1,
+                "strikeouts_stddev_last10": 1.3,
+            }
+        ]
+    )
+    joined_df = pd.DataFrame(
+        [
+            {
+                "game_date": "2026-05-10",
+                "player_name": "Jacob deGrom",
+                "participant_join_key": "mlbam_player:123",
+                "participant_id": "mlbam_player:123",
+                "participant_source_id": "123",
+                "participant_source_id_type": "mlbam_player",
+                "participant_name_norm": "jacob degrom",
+                "sport": "MLB",
+                "market_key": "pitcher_strikeouts",
+                "market_family": "player_prop",
+                "team": "TEX",
+                "opponent": "SEA",
+                "bookmaker": "DraftKings",
+                "bookmaker_key": "draftkings",
+                "event_id": "evt_1",
+                "side": "over",
+                "line": 5.5,
+                "price": -120,
+                MARKET_SELECTION_KEY_COLUMN: "MLB|pitcher_strikeouts|mlbam_player:123|over|5.5",
+                MARKET_OFFER_KEY_COLUMN: "MLB|pitcher_strikeouts|mlbam_player:123|over|5.5|draftkings",
+                "predicted_value": 6.8,
+                "predicted_strikeouts": 6.8,
+                "lower_bound": 5.7,
+                "upper_bound": 7.9,
+                "std_dev": 1.1,
+            }
+        ]
+    )
+    picks_df = pd.DataFrame(
+        [
+            {
+                "game_date": "2026-05-10",
+                "player_name": "Jacob deGrom",
+                "participant_join_key": "mlbam_player:123",
+                "participant_id": "mlbam_player:123",
+                "participant_source_id": "123",
+                "participant_source_id_type": "mlbam_player",
+                "participant_name_norm": "jacob degrom",
+                "book": "DraftKings",
+                "bookmaker_key": "draftkings",
+                "pick_side": "over",
+                "line": 5.5,
+                MARKET_OFFER_KEY_COLUMN: "MLB|pitcher_strikeouts|mlbam_player:123|over|5.5|draftkings",
+                "pick_type": "official",
+                "confidence_tier": "high",
+            }
+        ]
+    )
+
+    monkeypatch.setattr(
+        daily_card.pitcher_k_shadow,
+        "build_ridge_shadow_predictions",
+        lambda today_features, pitcher_games: (
+            pd.DataFrame(
+                [
+                    {
+                        "player_name": "Jacob deGrom",
+                        "pitcher": 123,
+                        "participant_join_key": "mlbam_player:123",
+                        "participant_id": "mlbam_player:123",
+                        "participant_source_id": "123",
+                        "participant_source_id_type": "mlbam_player",
+                        "participant_name_norm": "jacob degrom",
+                        "predicted_value": 6.2,
+                        "predicted_strikeouts": 6.2,
+                        "lower_bound": 5.0,
+                        "upper_bound": 7.4,
+                        "std_dev": 1.2,
+                    }
+                ]
+            ),
+            {
+                "model_name": "ridge_challenger",
+                "model_role": "challenger",
+                "model_version": "ridge_shadow_v1",
+            },
+        ),
+    )
+
+    def fake_build_picks_fn(df: pd.DataFrame) -> pd.DataFrame:
+        predicted_value = float(df["predicted_value"].iloc[0])
+        pick_side = "over" if predicted_value >= 6.0 else "under"
+        return pd.DataFrame(
+            [
+                {
+                    "game_date": "2026-05-10",
+                    "player_name": "Jacob deGrom",
+                    "participant_join_key": "mlbam_player:123",
+                    "participant_id": "mlbam_player:123",
+                    "participant_source_id": "123",
+                    "participant_source_id_type": "mlbam_player",
+                    "participant_name_norm": "jacob degrom",
+                    "book": "DraftKings",
+                    "bookmaker_key": "draftkings",
+                    "pick_side": pick_side,
+                    "line": 5.5,
+                    MARKET_OFFER_KEY_COLUMN: "MLB|pitcher_strikeouts|mlbam_player:123|over|5.5|draftkings",
+                    "pick_type": "official",
+                    "confidence_tier": "high",
+                }
+            ]
+        )
+
+    workflow = replace(
+        MLB_PITCHER_STRIKEOUT_WORKFLOW,
+        feature_builder=lambda starters_df, pitcher_games: pd.DataFrame(
+            [
+                {
+                    "player_name": "Jacob deGrom",
+                    "pitcher": 123,
+                    "participant_join_key": "mlbam_player:123",
+                    "participant_id": "mlbam_player:123",
+                    "participant_source_id": "123",
+                    "participant_source_id_type": "mlbam_player",
+                    "participant_name_norm": "jacob degrom",
+                    "sport": "MLB",
+                    "market_key": "pitcher_strikeouts",
+                    "market_family": "player_prop",
+                    "team": "TEX",
+                    "opponent": "SEA",
+                    "predicted_value": 6.8,
+                    "predicted_strikeouts": 6.8,
+                    "lower_bound": 5.7,
+                    "upper_bound": 7.9,
+                    "std_dev": 1.1,
+                }
+            ]
+        ),
+    )
+
+    output_path = daily_card.persist_pitcher_k_shadow_predictions(
+        starters_df=starters_df,
+        pitcher_games=pitcher_games,
+        joined_df=joined_df,
+        picks_df=picks_df,
+        workflow=workflow,
+        metadata={"artifact_version": 2, "training_window": {"train_split_date": "2025-08-01"}},
+        build_picks_fn=fake_build_picks_fn,
+    )
+
+    saved = pd.read_csv(output_path, keep_default_na=False)
+    assert output_path.exists()
+    assert set(saved["model_name"]) == {"xgboost_champion", "ridge_challenger"}
+    assert len(saved) == 2
+    assert saved["would_pick"].astype(str).str.lower().eq("true").all()
+
+
+def test_grade_pitcher_k_shadow_predictions_and_persist_report(monkeypatch):
+    shadow_rows = pd.DataFrame(
+        [
+            {
+                "shadow_row_key": "2026-05-10|xgboost_champion|row_a",
+                "candidate_key": "row_a",
+                "game_date": "2026-05-10",
+                "player_name": "Jacob deGrom",
+                "participant_join_key": "mlbam_player:123",
+                "participant_id": "mlbam_player:123",
+                "participant_source_id": "123",
+                "participant_source_id_type": "mlbam_player",
+                "participant_name_norm": "jacob degrom",
+                "sport": "MLB",
+                "market_key": "pitcher_strikeouts",
+                "market_family": "player_prop",
+                "prop_type": "pitcher_k",
+                "team": "TEX",
+                "opponent": "SEA",
+                "book": "DraftKings",
+                "bookmaker_key": "draftkings",
+                "event_id": "evt_1",
+                "side": "over",
+                "side_norm": "over",
+                "line": 5.5,
+                "price": -120,
+                MARKET_SELECTION_KEY_COLUMN: "sel_a",
+                MARKET_OFFER_KEY_COLUMN: "offer_a",
+                "model_name": "xgboost_champion",
+                "model_role": "champion",
+                "model_version": "champion_v1",
+                "policy_version": "policy_v1",
+                "predicted_value": 6.8,
+                "predicted_strikeouts": 6.8,
+                "lower_bound": 5.7,
+                "upper_bound": 7.9,
+                "std_dev": 1.1,
+                "edge": 1.3,
+                "would_pick": True,
+                "pick_rank": 1,
+                "pick_type": "official",
+                "confidence_tier": "high",
+                "actual_value": "",
+                "result": "",
+                "profit_units": "",
+                "graded_at": "",
+                "tracking_regime": "current_workflow",
+            },
+            {
+                "shadow_row_key": "2026-05-10|ridge_challenger|row_a",
+                "candidate_key": "row_a",
+                "game_date": "2026-05-10",
+                "player_name": "Jacob deGrom",
+                "participant_join_key": "mlbam_player:123",
+                "participant_id": "mlbam_player:123",
+                "participant_source_id": "123",
+                "participant_source_id_type": "mlbam_player",
+                "participant_name_norm": "jacob degrom",
+                "sport": "MLB",
+                "market_key": "pitcher_strikeouts",
+                "market_family": "player_prop",
+                "prop_type": "pitcher_k",
+                "team": "TEX",
+                "opponent": "SEA",
+                "book": "DraftKings",
+                "bookmaker_key": "draftkings",
+                "event_id": "evt_1",
+                "side": "over",
+                "side_norm": "over",
+                "line": 5.5,
+                "price": -120,
+                MARKET_SELECTION_KEY_COLUMN: "sel_a",
+                MARKET_OFFER_KEY_COLUMN: "offer_a",
+                "model_name": "ridge_challenger",
+                "model_role": "challenger",
+                "model_version": "ridge_v1",
+                "policy_version": "policy_v1",
+                "predicted_value": 6.2,
+                "predicted_strikeouts": 6.2,
+                "lower_bound": 5.0,
+                "upper_bound": 7.4,
+                "std_dev": 1.2,
+                "edge": 0.7,
+                "would_pick": True,
+                "pick_rank": 1,
+                "pick_type": "official",
+                "confidence_tier": "high",
+                "actual_value": "",
+                "result": "",
+                "profit_units": "",
+                "graded_at": "",
+                "tracking_regime": "current_workflow",
+            },
+            ]
+        )
+    daily_card.TRACKING_DIR.mkdir(parents=True, exist_ok=True)
+    shadow_rows.to_csv(daily_card.PITCHER_K_SHADOW_TRACKING_PATH, index=False)
+
+    monkeypatch.setattr(
+        daily_card,
+        "load_pitcher_results_from_statcast",
+        lambda game_date: pd.DataFrame(
+            [
+                {
+                    "game_date": game_date,
+                    "pitcher": 123,
+                    "player_name": "Jacob deGrom",
+                    "strikeouts": 7,
+                    "walks": 1,
+                }
+            ]
+        ),
+    )
+
+    grade_result = daily_card.grade_pitcher_k_shadow_predictions_from_statcast(game_date="2026-05-10")
+    report = daily_card.persist_pitcher_k_shadow_comparison_report()
+
+    loaded = pd.read_csv(daily_card.PITCHER_K_SHADOW_TRACKING_PATH, keep_default_na=False)
+    summary = json.loads(daily_card.PITCHER_K_SHADOW_SUMMARY_PATH.read_text(encoding="utf-8"))
+
+    assert grade_result["updated_rows"] == 2
+    assert loaded["actual_value"].astype(str).tolist() == ["7", "7"]
+    assert loaded["result"].tolist() == ["W", "W"]
+    assert report["summary"]["available"] is True
+    assert summary["available"] is True
+    assert daily_card.PITCHER_K_SHADOW_OVERLAP_PATH.exists()
+    assert daily_card.PITCHER_K_SHADOW_REGRESSION_PLOT_PATH.exists()
+    assert daily_card.PITCHER_K_SHADOW_WORKFLOW_PLOT_PATH.exists()

--- a/MLB/tests/pitcher_k/test_shadow.py
+++ b/MLB/tests/pitcher_k/test_shadow.py
@@ -1,0 +1,304 @@
+import pandas as pd
+import pytest
+
+from common.identity import MARKET_OFFER_KEY_COLUMN, MARKET_SELECTION_KEY_COLUMN
+from pitcher_k import shadow
+
+
+def _base_shadow_row(**overrides) -> dict:
+    row = {
+        "shadow_row_key": "",
+        "candidate_key": "",
+        "game_date": "2026-05-10",
+        "player_name": "Jacob deGrom",
+        "participant_join_key": "mlbam_player:123",
+        "participant_id": "mlbam_player:123",
+        "participant_source_id": "123",
+        "participant_source_id_type": "mlbam_player",
+        "participant_name_norm": "jacob degrom",
+        "sport": "MLB",
+        "market_key": "pitcher_strikeouts",
+        "market_family": "player_prop",
+        "prop_type": "pitcher_k",
+        "team": "TEX",
+        "opponent": "SEA",
+        "book": "DraftKings",
+        "bookmaker_key": "draftkings",
+        "event_id": "evt_1",
+        "side": "over",
+        "side_norm": "over",
+        "line": 5.5,
+        "price": -120,
+        MARKET_SELECTION_KEY_COLUMN: "MLB|pitcher_strikeouts|mlbam_player:123|over|5.5",
+        MARKET_OFFER_KEY_COLUMN: "MLB|pitcher_strikeouts|mlbam_player:123|over|5.5|draftkings",
+        "model_name": shadow.CHAMPION_MODEL_NAME,
+        "model_role": shadow.CHAMPION_MODEL_ROLE,
+        "model_version": "champion_v1",
+        "policy_version": "policy_v1",
+        "predicted_value": 6.8,
+        "predicted_strikeouts": 6.8,
+        "lower_bound": 5.7,
+        "upper_bound": 7.9,
+        "std_dev": 1.1,
+        "edge": 1.3,
+        "would_pick": True,
+        "pick_rank": 1,
+        "pick_type": "official",
+        "confidence_tier": "high",
+        "actual_value": "7",
+        "result": "W",
+        "profit_units": 0.8333333333,
+        "graded_at": "2026-05-11T10:00:00-04:00",
+        "tracking_regime": "current_workflow",
+    }
+    row.update(overrides)
+    if not row["candidate_key"]:
+        row["candidate_key"] = f"{row['game_date']}|{row[MARKET_OFFER_KEY_COLUMN]}"
+    if not row["shadow_row_key"]:
+        row["shadow_row_key"] = f"{row['game_date']}|{row['model_name']}|{row['candidate_key']}"
+    return row
+
+
+def test_build_shadow_candidate_rows_marks_actionable_pick_and_rank():
+    joined_df = pd.DataFrame(
+        [
+            {
+                "game_date": "2026-05-10",
+                "player_name": "Jacob deGrom",
+                "participant_join_key": "mlbam_player:123",
+                "participant_id": "mlbam_player:123",
+                "participant_source_id": "123",
+                "participant_source_id_type": "mlbam_player",
+                "participant_name_norm": "jacob degrom",
+                "sport": "MLB",
+                "market_key": "pitcher_strikeouts",
+                "market_family": "player_prop",
+                "team": "TEX",
+                "opponent": "SEA",
+                "bookmaker": "DraftKings",
+                "bookmaker_key": "draftkings",
+                "event_id": "evt_1",
+                "side": "over",
+                "line": 5.5,
+                "price": -120,
+                MARKET_SELECTION_KEY_COLUMN: "MLB|pitcher_strikeouts|mlbam_player:123|over|5.5",
+                MARKET_OFFER_KEY_COLUMN: "MLB|pitcher_strikeouts|mlbam_player:123|over|5.5|draftkings",
+                "predicted_value": 6.8,
+                "predicted_strikeouts": 6.8,
+                "lower_bound": 5.7,
+                "upper_bound": 7.9,
+                "std_dev": 1.1,
+            },
+            {
+                "game_date": "2026-05-10",
+                "player_name": "Jacob deGrom",
+                "participant_join_key": "mlbam_player:123",
+                "participant_id": "mlbam_player:123",
+                "participant_source_id": "123",
+                "participant_source_id_type": "mlbam_player",
+                "participant_name_norm": "jacob degrom",
+                "sport": "MLB",
+                "market_key": "pitcher_strikeouts",
+                "market_family": "player_prop",
+                "team": "TEX",
+                "opponent": "SEA",
+                "bookmaker": "BetMGM",
+                "bookmaker_key": "betmgm",
+                "event_id": "evt_1",
+                "side": "under",
+                "line": 6.5,
+                "price": -110,
+                MARKET_SELECTION_KEY_COLUMN: "MLB|pitcher_strikeouts|mlbam_player:123|under|6.5",
+                MARKET_OFFER_KEY_COLUMN: "MLB|pitcher_strikeouts|mlbam_player:123|under|6.5|betmgm",
+                "predicted_value": 6.8,
+                "predicted_strikeouts": 6.8,
+                "lower_bound": 5.7,
+                "upper_bound": 7.9,
+                "std_dev": 1.1,
+            },
+        ]
+    )
+    picks_df = pd.DataFrame(
+        [
+            {
+                "game_date": "2026-05-10",
+                "player_name": "Jacob deGrom",
+                "participant_join_key": "mlbam_player:123",
+                "book": "DraftKings",
+                "bookmaker_key": "draftkings",
+                "pick_side": "over",
+                "line": 5.5,
+                MARKET_OFFER_KEY_COLUMN: "MLB|pitcher_strikeouts|mlbam_player:123|over|5.5|draftkings",
+                "pick_type": "official",
+                "confidence_tier": "high",
+            }
+        ]
+    )
+
+    rows = shadow.build_shadow_candidate_rows(
+        joined_df,
+        picks_df,
+        model_name=shadow.CHAMPION_MODEL_NAME,
+        model_role=shadow.CHAMPION_MODEL_ROLE,
+        model_version="champion_v1",
+        policy_version="policy_v1",
+        tracking_regime="current_workflow",
+        game_date="2026-05-10",
+    )
+
+    assert len(rows) == 2
+    selected = rows[rows["would_pick"]].reset_index(drop=True)
+    skipped = rows[~rows["would_pick"]].reset_index(drop=True)
+    assert len(selected) == 1
+    assert selected.loc[0, "pick_rank"] == pytest.approx(1)
+    assert selected.loc[0, "pick_type"] == "official"
+    assert selected.loc[0, "book"] == "DraftKings"
+    assert skipped.loc[0, "pick_type"] == ""
+    assert skipped.loc[0, "actual_value"] == ""
+
+
+def test_build_shadow_comparison_report_summarizes_overlap_and_disagreement():
+    rows = pd.DataFrame(
+        [
+            _base_shadow_row(
+                candidate_key="2026-05-10|offer_agree",
+                shadow_row_key="2026-05-10|xgboost_champion|2026-05-10|offer_agree",
+                model_name=shadow.CHAMPION_MODEL_NAME,
+                model_role=shadow.CHAMPION_MODEL_ROLE,
+                player_name="Jacob deGrom",
+                participant_join_key="mlbam_player:123",
+                line=5.5,
+                side="over",
+                side_norm="over",
+                book="DraftKings",
+                bookmaker_key="draftkings",
+                edge=1.3,
+                actual_value="7",
+                result="W",
+                profit_units=0.83,
+                would_pick=True,
+            ),
+            _base_shadow_row(
+                candidate_key="2026-05-10|offer_agree",
+                shadow_row_key="2026-05-10|ridge_challenger|2026-05-10|offer_agree",
+                model_name=shadow.CHALLENGER_MODEL_NAME,
+                model_role=shadow.CHALLENGER_MODEL_ROLE,
+                model_version="ridge_v1",
+                player_name="Jacob deGrom",
+                participant_join_key="mlbam_player:123",
+                predicted_value=6.4,
+                predicted_strikeouts=6.4,
+                lower_bound=5.2,
+                upper_bound=7.6,
+                std_dev=1.2,
+                edge=0.9,
+                actual_value="7",
+                result="W",
+                profit_units=0.83,
+                would_pick=True,
+            ),
+            _base_shadow_row(
+                candidate_key="2026-05-11|offer_over",
+                shadow_row_key="2026-05-11|xgboost_champion|2026-05-11|offer_over",
+                model_name=shadow.CHAMPION_MODEL_NAME,
+                model_role=shadow.CHAMPION_MODEL_ROLE,
+                player_name="Max Fried",
+                participant_join_key="mlbam_player:456",
+                line=5.5,
+                side="over",
+                side_norm="over",
+                book="FanDuel",
+                bookmaker_key="fanduel",
+                actual_value="3",
+                result="L",
+                profit_units=-1.0,
+                would_pick=True,
+            ),
+            _base_shadow_row(
+                candidate_key="2026-05-11|offer_over",
+                shadow_row_key="2026-05-11|ridge_challenger|2026-05-11|offer_over",
+                model_name=shadow.CHALLENGER_MODEL_NAME,
+                model_role=shadow.CHALLENGER_MODEL_ROLE,
+                model_version="ridge_v1",
+                player_name="Max Fried",
+                participant_join_key="mlbam_player:456",
+                line=5.5,
+                side="over",
+                side_norm="over",
+                book="FanDuel",
+                bookmaker_key="fanduel",
+                predicted_value=4.2,
+                predicted_strikeouts=4.2,
+                lower_bound=3.3,
+                upper_bound=5.1,
+                std_dev=0.9,
+                edge=-1.3,
+                actual_value="3",
+                result="",
+                profit_units="",
+                would_pick=False,
+                pick_rank="",
+                pick_type="",
+                confidence_tier="",
+            ),
+            _base_shadow_row(
+                candidate_key="2026-05-11|offer_under",
+                shadow_row_key="2026-05-11|xgboost_champion|2026-05-11|offer_under",
+                model_name=shadow.CHAMPION_MODEL_NAME,
+                model_role=shadow.CHAMPION_MODEL_ROLE,
+                player_name="Max Fried",
+                participant_join_key="mlbam_player:456",
+                line=5.5,
+                side="under",
+                side_norm="under",
+                book="FanDuel",
+                bookmaker_key="fanduel",
+                actual_value="3",
+                result="",
+                profit_units="",
+                would_pick=False,
+                pick_rank="",
+                pick_type="",
+                confidence_tier="",
+            ),
+            _base_shadow_row(
+                candidate_key="2026-05-11|offer_under",
+                shadow_row_key="2026-05-11|ridge_challenger|2026-05-11|offer_under",
+                model_name=shadow.CHALLENGER_MODEL_NAME,
+                model_role=shadow.CHALLENGER_MODEL_ROLE,
+                model_version="ridge_v1",
+                player_name="Max Fried",
+                participant_join_key="mlbam_player:456",
+                line=5.5,
+                side="under",
+                side_norm="under",
+                book="FanDuel",
+                bookmaker_key="fanduel",
+                predicted_value=4.2,
+                predicted_strikeouts=4.2,
+                lower_bound=3.3,
+                upper_bound=5.1,
+                std_dev=0.9,
+                edge=1.3,
+                actual_value="3",
+                result="W",
+                profit_units=0.91,
+                would_pick=True,
+                pick_rank=1,
+                pick_type="official",
+                confidence_tier="high",
+            ),
+        ]
+    )
+
+    report = shadow.build_shadow_comparison_report(rows)
+
+    assert report["available"] is True
+    assert not report["overlap_df"].empty
+    assert report["summary"]["models"][shadow.CHAMPION_MODEL_NAME]["pick_count"] == 2
+    assert report["summary"]["models"][shadow.CHALLENGER_MODEL_NAME]["pick_count"] == 2
+    slices = {row["comparison_slice"]: row for row in report["summary"]["agreement_slices"]}
+    assert slices["agreement"]["rows"] == 1
+    assert slices["disagreement"]["rows"] == 1
+    assert report["summary"]["rolling_regression_windows"]
+    assert report["summary"]["rolling_workflow_windows"]


### PR DESCRIPTION
Implemented the full pitcher_k shadow grading and comparison workflow in the repo.
The core logic is in shadow.py (line 1), and it’s wired into the daily runtime in run_daily_card.py (line 1). The daily card now:
persists a shared candidate-universe shadow artifact for xgboost_champion and ridge_challenger
grades pending shadow rows from Statcast once outcomes exist
rebuilds a forward comparison report from overlapping tracked rows
writes these artifacts under data/tracking:pitcher_k_shadow_predictions.csv
pitcher_k_shadow_overlap.csv
pitcher_k_shadow_summary.json
pitcher_k_shadow_regression.png
pitcher_k_shadow_workflow.png

A couple of implementation choices to call out:
would_pick is the model’s actionable best-market row for that pitcher after pass rows are excluded, before public posting caps.
The initial challenger is ridge_challenger, since that was the cleanest shadow baseline from the earlier bakeoff.
The comparison report includes regression metrics, calibration, workflow ROI/profit, agreement vs disagreement slices, by-book and by-line-band summaries, plus rolling 7/14/30 window summaries in JSON.
I also added focused coverage in test_shadow.py (line 1), test_run_daily_card_shadow.py (line 1), and updated conftest.py (line 1) / test_run_daily_card.py (line 1) for path isolation. Verification passed: 38 passed.