### PR TITLE
Patched [amplify.yml (line 1)](/c:/ProGramble/proGramble/amplify.yml:…

### DIFF
--- a/amplify.yml
+++ b/amplify.yml
@@ -2,19 +2,18 @@ version: 1
 applications:
   - appRoot: web
     frontend:
-      buildPath: /
       phases:
         preBuild:
           commands:
-            - cd web && npm ci
+            - npm ci
         build:
           commands:
-            - cd web && npm run build
+            - npm run build
       artifacts:
-        baseDirectory: web/.next
+        baseDirectory: .next
         files:
           - "**/*"
       cache:
         paths:
-          - web/node_modules/**/*
-          - web/.next/cache/**/*
+          - node_modules/**/*
+          - .next/cache/**/*

--- a/docs/web-amplify-staging.md
+++ b/docs/web-amplify-staging.md
@@ -25,10 +25,10 @@ The current staging API base URL points at the ECS Express service that is alrea
 
 The checked-in `amplify.yml` tells Amplify to:
 
-- run the build from the repository root
-- install dependencies with `cd web && npm ci`
-- build the app with `cd web && npm run build`
-- publish the `web/.next` output for the `web` app
+- run the build from the Amplify app root
+- install dependencies with `npm ci`
+- build the app with `npm run build`
+- publish the `.next` output for the `web` app
 
 This repo is a monorepo, so the Amplify branch configuration must use `web` as the app root.
 


### PR DESCRIPTION
…1) so Amplify builds from the app root it is already using: