### PR TITLE
ssue found in the pick policy. In [policy.py (line 43)](/C:\\ProGramb…

### DIFF
--- a/MLB/src/jobs/run_daily_card.py
+++ b/MLB/src/jobs/run_daily_card.py
@@ -2786,17 +2786,41 @@ def run_workflow_daily_card(
                 metadata=metadata,
                 game_date=workflow_game_date,
             )
-            validate_final_picks_contract(picks_df)
+            if picks_df.empty:
+                run_status = "degraded"
+                run_message = _build_no_edges_message(
+                    workflow=workflow,
+                    diagnostics=edge_diagnostics,
+                )
+                workflow_diagnostics["status"] = run_status
+                workflow_diagnostics["message"] = run_message
+                print(f"WARNING: {run_message}")
+                picks_df = _tag_workflow_frame(empty_final_picks_df(), workflow)
+                post_df = _tag_workflow_frame(empty_final_picks_df(), workflow)
+                picks_df = _annotate_workflow_provenance(
+                    picks_df,
+                    workflow=workflow,
+                    metadata=metadata,
+                    game_date=workflow_game_date,
+                )
+                post_df = _annotate_workflow_provenance(
+                    post_df,
+                    workflow=workflow,
+                    metadata=metadata,
+                    game_date=workflow_game_date,
+                )
+            else:
+                validate_final_picks_contract(picks_df)
 
-            post_df = filter_postable_picks_fn(picks_df)
-            post_df = _tag_workflow_frame(post_df, workflow)
-            post_df = _annotate_workflow_provenance(
-                post_df,
-                workflow=workflow,
-                metadata=metadata,
-                game_date=workflow_game_date,
-            )
-            validate_final_picks_contract(post_df, require_non_empty_frame=False)
+                post_df = filter_postable_picks_fn(picks_df)
+                post_df = _tag_workflow_frame(post_df, workflow)
+                post_df = _annotate_workflow_provenance(
+                    post_df,
+                    workflow=workflow,
+                    metadata=metadata,
+                    game_date=workflow_game_date,
+                )
+                validate_final_picks_contract(post_df, require_non_empty_frame=False)
     except requests.RequestException as exc:
         run_status = "degraded"
         run_message = (

--- a/MLB/src/odds/policy.py
+++ b/MLB/src/odds/policy.py
@@ -41,6 +41,9 @@ class PickRankingPolicy:
     postable_limits: PostablePickLimits = field(default_factory=PostablePickLimits)
 
     def classify_pick_type(self, edge: float) -> str:
+        if pd.isna(edge) or float(edge) <= 0:
+            return "pass"
+
         abs_edge = abs(edge)
 
         if abs_edge >= self.official_edge_threshold:
@@ -94,6 +97,8 @@ class PickRankingPolicy:
 
         over_metric = self._resolve_side_choice_metric(best_over, fallback=over_edge)
         under_metric = self._resolve_side_choice_metric(best_under, fallback=under_edge)
+        over_metric = self._positive_metric_or_none(over_metric)
+        under_metric = self._positive_metric_or_none(under_metric)
 
         if over_metric is None and under_metric is None:
             return pd.Series(dtype="object")
@@ -170,6 +175,12 @@ class PickRankingPolicy:
         if self.side_choice_metric_column in row and pd.notna(row[self.side_choice_metric_column]):
             return float(row[self.side_choice_metric_column])
         return fallback
+
+    @staticmethod
+    def _positive_metric_or_none(metric: float | None) -> float | None:
+        if metric is None or pd.isna(metric) or float(metric) <= 0:
+            return None
+        return float(metric)
 
     @staticmethod
     def _finalize_choice(row: pd.Series, *, edge: float, pick_side: str) -> pd.Series:

--- a/MLB/tests/jobs/test_run_daily_card.py
+++ b/MLB/tests/jobs/test_run_daily_card.py
@@ -1359,6 +1359,109 @@ def test_run_workflow_daily_card_allows_empty_postable_picks(monkeypatch):
     assert result_diagnostics["workflow"] == "pitcher_k"
 
 
+def test_run_workflow_daily_card_degrades_when_pick_builder_returns_no_positive_picks(monkeypatch):
+    starters_df = pd.DataFrame(
+        [
+            {
+                "game_date": "2026-04-19",
+                "game_pk": 123456,
+                "pitcher": 1,
+                "player_name": "Jacob deGrom",
+                "team": "TEX",
+                "opponent": "SEA",
+                "home_team": "TEX",
+                "away_team": "SEA",
+                "is_home": 1,
+                "p_throws": "R",
+            }
+        ]
+    )
+    pitcher_games = pd.DataFrame(
+        [
+            {
+                "game_date": "2026-04-18",
+                "game_pk": 111111,
+                "pitcher": 1,
+                "player_name": "Jacob deGrom",
+                "pitching_team": "TEX",
+                "opponent_team": "SEA",
+            }
+        ]
+    )
+    today_preds = pd.DataFrame(
+        [
+            {
+                "player_name": "Jacob deGrom",
+                "player_name_norm": "jacob degrom",
+                "pitcher": 1,
+                "team": "TEX",
+                "opponent": "SEA",
+                "predicted_strikeouts": 5.0,
+            }
+        ]
+    )
+    joined_df = pd.DataFrame(
+        [
+            {
+                "player_name_proj": "Jacob deGrom",
+                "player_name_norm": "jacob degrom",
+                "predicted_value": 5.0,
+                "predicted_strikeouts": 5.0,
+                "bookmaker": "DraftKings",
+                "side": "Over",
+                "line": 6.5,
+                "price": 110,
+            }
+        ]
+    )
+    filter_called = {"value": False}
+
+    monkeypatch.setattr(daily_card, "load_workflow_history_artifact", lambda workflow: pitcher_games)
+    monkeypatch.setattr(daily_card, "load_workflow_model_artifact", lambda workflow: "fake_model")
+    monkeypatch.setattr(daily_card, "load_model_metadata", lambda workflow=None: {"target": "strikeouts"})
+    monkeypatch.setattr(
+        daily_card,
+        "build_today_predictions_for_workflow",
+        lambda *, starters_df, pitcher_games, model, workflow: today_preds,
+    )
+    monkeypatch.setattr(
+        daily_card,
+        "run_edge_pipeline",
+        lambda preds, market, **kwargs: (
+            joined_df,
+            joined_df,
+            {"raw_event_count": 1, "normalized_odds_rows": 1, "joined_rows": 1},
+        ),
+    )
+    monkeypatch.setattr(
+        daily_card,
+        "build_daily_picks",
+        lambda joined, policy, prediction_column="predicted_value": pd.DataFrame(),
+    )
+
+    def _unexpected_filter(*args, **kwargs):
+        filter_called["value"] = True
+        raise AssertionError("filter_postable_picks should not run when no picks were built.")
+
+    monkeypatch.setattr(daily_card, "filter_postable_picks", _unexpected_filter)
+
+    _, _, result_picks, result_post, result_status, result_message, result_diagnostics = daily_card.run_workflow_daily_card(
+        starters_df=starters_df,
+        workflow=daily_card.MLB_PITCHER_STRIKEOUT_WORKFLOW,
+    )
+
+    assert not filter_called["value"]
+    assert result_picks.empty
+    assert result_post.empty
+    assert set(daily_card.empty_final_picks_df().columns).issubset(result_picks.columns)
+    assert set(daily_card.empty_final_picks_df().columns).issubset(result_post.columns)
+    assert result_status == "degraded"
+    assert result_message == "No edges or picks were generated for today's pitcher_k run."
+    assert result_diagnostics["workflow"] == "pitcher_k"
+    assert result_diagnostics["pick_rows"] == 0
+    assert result_diagnostics["postable_rows"] == 0
+
+
 def test_run_daily_card_preserves_other_workflow_picks_when_one_workflow_has_no_postable_rows(monkeypatch, tmp_path):
     starters_df = pd.DataFrame(
         [

--- a/MLB/tests/odds/test_create_picks.py
+++ b/MLB/tests/odds/test_create_picks.py
@@ -78,6 +78,38 @@ def test_build_daily_picks_selects_best_under_market_when_under_edge_is_stronger
     assert picks.loc[0, "line"] == 3.5
     assert picks.loc[0, "edge"] == 3.5 - 1.2
 
+
+def test_build_daily_picks_returns_empty_when_no_side_has_positive_edge():
+    joined_df = pd.DataFrame(
+        [
+            {
+                "player_name_proj": "Negative Edge Over",
+                "team": "AAA",
+                "opponent": "BBB",
+                "predicted_strikeouts": 5.0,
+                "bookmaker": "DraftKings",
+                "side": "Over",
+                "line": 6.5,
+                "price": 110,
+            },
+            {
+                "player_name_proj": "Negative Edge Over",
+                "team": "AAA",
+                "opponent": "BBB",
+                "predicted_strikeouts": 5.0,
+                "bookmaker": "FanDuel",
+                "side": "Under",
+                "line": 4.5,
+                "price": -110,
+            },
+        ]
+    )
+
+    picks = build_daily_picks(joined_df)
+
+    assert picks.empty
+
+
 def test_build_daily_picks_assigns_official_lean_and_pass():
     joined_df = pd.DataFrame(
         [
@@ -431,7 +463,7 @@ def test_build_daily_picks_exposes_raw_and_adjusted_ranking_fields():
                 "team": "LAD",
                 "opponent": "SFG",
                 "prop_type": "pitcher_k",
-                "predicted_strikeouts": 8.0,
+                "predicted_strikeouts": 7.0,
                 "bookmaker": "FanDuel",
                 "side": "Under",
                 "line": 7.5,
@@ -525,11 +557,10 @@ def test_build_daily_picks_pitcher_walks_policy_prefers_higher_expected_return_o
                 "market_key": "pitcher_walks",
                 "predicted_walks": 2.2,
                 "predicted_value": 2.2,
-                "std_dev": 0.2,
                 "bookmaker": "DraftKings",
                 "side": "Under",
-                "line": 2.5,
-                "price": -220,
+                "line": 3.0,
+                "price": -500,
             },
             {
                 "player_name_proj": "Tarik Skubal",
@@ -539,11 +570,10 @@ def test_build_daily_picks_pitcher_walks_policy_prefers_higher_expected_return_o
                 "market_key": "pitcher_walks",
                 "predicted_walks": 2.2,
                 "predicted_value": 2.2,
-                "std_dev": 0.2,
                 "bookmaker": "FanDuel",
                 "side": "Under",
-                "line": 2.0,
-                "price": 190,
+                "line": 2.5,
+                "price": -220,
             },
         ]
     )
@@ -560,3 +590,46 @@ def test_build_daily_picks_pitcher_walks_policy_prefers_higher_expected_return_o
     assert picks.loc[0, "expected_return"] > 0
     assert picks.loc[0, "selection_expected_return"] == pytest.approx(picks.loc[0, "expected_return"])
     assert picks.loc[0, "pick_type"] in {"official", "lean"}
+
+
+def test_build_daily_picks_pitcher_walks_returns_empty_when_best_expected_return_is_non_positive():
+    joined_df = pd.DataFrame(
+        [
+            {
+                "player_name_proj": "Tarik Skubal",
+                "team": "DET",
+                "opponent": "CLE",
+                "prop_type": "pitcher_bb",
+                "market_key": "pitcher_walks",
+                "predicted_walks": 2.2,
+                "predicted_value": 2.2,
+                "std_dev": 0.2,
+                "bookmaker": "DraftKings",
+                "side": "Under",
+                "line": 2.5,
+                "price": -300,
+            },
+            {
+                "player_name_proj": "Tarik Skubal",
+                "team": "DET",
+                "opponent": "CLE",
+                "prop_type": "pitcher_bb",
+                "market_key": "pitcher_walks",
+                "predicted_walks": 2.2,
+                "predicted_value": 2.2,
+                "std_dev": 0.2,
+                "bookmaker": "FanDuel",
+                "side": "Over",
+                "line": 2.0,
+                "price": -300,
+            },
+        ]
+    )
+
+    picks = build_daily_picks(
+        joined_df,
+        policy=DEFAULT_MLB_PITCHER_WALKS_POLICY,
+        prediction_column="predicted_value",
+    )
+
+    assert picks.empty

--- a/MLB/tests/odds/test_policy.py
+++ b/MLB/tests/odds/test_policy.py
@@ -16,6 +16,7 @@ def test_default_policy_preserves_thresholds_and_caps():
     assert policy.classify_pick_type(0.75) == "official"
     assert policy.classify_pick_type(0.40) == "lean"
     assert policy.classify_pick_type(0.39) == "pass"
+    assert policy.classify_pick_type(-0.75) == "pass"
     assert policy.classify_confidence_tier(0.50) == "high"
     assert policy.classify_confidence_tier(0.30) == "medium"
     assert policy.classify_confidence_tier(0.15) == "low"
@@ -91,6 +92,20 @@ def test_policy_can_change_edge_tie_break_preference_and_postable_caps():
     assert limits.max_leans == 1
 
 
+def test_choose_pick_side_returns_empty_when_neither_side_has_positive_edge():
+    policy = DEFAULT_MLB_PITCHER_STRIKEOUT_POLICY
+    best_over = pd.Series({"line": 6.5, "bookmaker": "DraftKings"})
+    best_under = pd.Series({"line": 4.5, "bookmaker": "FanDuel"})
+
+    chosen = policy.choose_pick_side(
+        best_over=best_over,
+        best_under=best_under,
+        predicted=5.0,
+    )
+
+    assert chosen.empty
+
+
 def test_default_pitcher_walks_policy_uses_expected_return_metrics():
     policy = DEFAULT_MLB_PITCHER_WALKS_POLICY
 
@@ -103,3 +118,4 @@ def test_default_pitcher_walks_policy_uses_expected_return_metrics():
     assert policy.classify_pick_type(0.08) == "official"
     assert policy.classify_pick_type(0.02) == "lean"
     assert policy.classify_pick_type(0.01) == "pass"
+    assert policy.classify_pick_type(-0.08) == "pass"


### PR DESCRIPTION
…le\\proGramble\\MLB\\src\\odds\\policy.py:43), classify_pick_type() was using abs(...), so a negative edge or negative expected_return could still be labeled lean or official. On top of that, choose_pick_side() would still select a side when both over and under metrics were non-positive, effectively picking the “least bad” market and letting it flow downstream.